### PR TITLE
Keep TaskProviders out of the unit-test task's onlyIf spec for configuration-cache compatibility

### DIFF
--- a/compose-nav-graph-gradle/src/main/kotlin/com/github/skydoves/navgraph/gradle/NavGraphGradlePlugin.kt
+++ b/compose-nav-graph-gradle/src/main/kotlin/com/github/skydoves/navgraph/gradle/NavGraphGradlePlugin.kt
@@ -708,6 +708,10 @@ public class NavGraphGradlePlugin : Plugin<Project> {
       gradle.taskGraph.whenReady {
         val active = wired.filter { hasTask(it.anchor.get()) }
         if (active.isEmpty()) return@whenReady
+        // Materialized OUTSIDE the closures attached to the test task: the configuration cache serializes that
+        // task's whole state — sysprops AND its onlyIf specs — so a spec capturing `active` would drag each
+        // Wired's TaskProviders (realized DefaultTasks) into the entry and fail serialization. Plain Files don't.
+        val renderListFiles = active.map { it.renderListFile.get().asFile }
         agpTest.get().apply {
           filter {
             includeTestsMatching("*NavGraphRobolectricRenderTest")
@@ -723,9 +727,7 @@ public class NavGraphGradlePlugin : Plugin<Project> {
           }
           // Run iff ANY active pipeline has a non-empty render list (a Layoutlib failure to fill somewhere).
           onlyIf {
-            active.any { w ->
-              w.renderListFile.get().asFile.let { it.isFile && it.readText().isNotBlank() }
-            }
+            renderListFiles.any { it.isFile && it.readText().isNotBlank() }
           }
           // Force the render to run when requested (the prior thumbnails aren't a tracked output of the test).
           outputs.upToDateWhen { false }


### PR DESCRIPTION
### 🎯 Goal
Make the thumbnail render pipeline compatible with the Gradle configuration cache, so `generateNavGraph` / `exportNavGraphHtml` no longer need `--no-configuration-cache`. Fixes #1.

### 🛠 Implementation details
The configuration cache serializes the AGP unit-test task's whole state, including its `onlyIf` specs. The render wiring's `onlyIf` captured the `Wired` records, whose `anchor`/`RoboSpec.renderLayoutlib` fields hold `TaskProvider`s — realized `DefaultTask`s — so storing the cache entry failed:

```
Task `:app:testDebugUnitTest` of type `com.android.build.gradle.tasks.factory.AndroidUnitTest`:
cannot serialize object of type 'org.gradle.api.DefaultTask', a subtype of 'org.gradle.api.Task',
as these are not supported with the configuration cache.
```

The fix materializes the render-list `File`s inside `whenReady` *before* configuring the test task, and lets the `onlyIf` spec capture only that `List<File>` — plain `File`s serialize fine. The sysprops were already eager strings. No behavior change; the spec evaluates the same files at the same time.

### ✍️ Explain examples
On a Compose Multiplatform single-module app (Gradle 8.13, AGP 8.13.1, Kotlin 2.3.21) with the configuration cache enabled:

```
./gradlew :composeApp:generateNavGraph :composeApp:exportNavGraphHtml
```

failed before this change ("Configuration cache entry discarded with 2 problems") and required `--no-configuration-cache`; with it the entry stores and the pipeline runs normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)