### PR TITLE
Use the module's own linked resources when it is the Android application

### DIFF
--- a/compose-nav-graph-gradle/src/main/kotlin/com/github/skydoves/navgraph/gradle/NavGraphGradlePlugin.kt
+++ b/compose-nav-graph-gradle/src/main/kotlin/com/github/skydoves/navgraph/gradle/NavGraphGradlePlugin.kt
@@ -1052,18 +1052,22 @@ public class NavGraphGradlePlugin : Plugin<Project> {
     }
   }
 
-  /** The first `com.android.application` project that declares a dependency on [module]. Checks the always-created
-   *  `implementation` configuration (variant runtime classpaths like `devDebugRuntimeClasspath` are registered
-   *  lazily, so iterating their names at `projectsEvaluated` is unreliable). */
+  /** The `com.android.application` whose linked resources feed the KMP render: [module] ITSELF when it carries the
+   *  application plugin (a single-module Compose-Multiplatform app — KMP + `com.android.application` on one module —
+   *  links its own R/.ap_, so it needs no external consumer), else the first application project that declares a
+   *  dependency on [module]. Checks the always-created `implementation` configuration (variant runtime classpaths
+   *  like `devDebugRuntimeClasspath` are registered lazily, so iterating their names at `projectsEvaluated` is
+   *  unreliable). */
   private fun findConsumingAndroidApp(module: Project): Project? =
-    module.rootProject.allprojects.firstOrNull { candidate ->
-      candidate.path != module.path &&
-        candidate.plugins.hasPlugin("com.android.application") &&
-        candidate.configurations.findByName("implementation")
-          ?.allDependencies?.any {
-            it is ProjectDependency && projectDependencyPath(it) == module.path
-          } == true
-    }
+    module.takeIf { it.plugins.hasPlugin("com.android.application") }
+      ?: module.rootProject.allprojects.firstOrNull { candidate ->
+        candidate.path != module.path &&
+          candidate.plugins.hasPlugin("com.android.application") &&
+          candidate.configurations.findByName("implementation")
+            ?.allDependencies?.any {
+              it is ProjectDependency && projectDependencyPath(it) == module.path
+            } == true
+      }
 
   /** The consuming app's debug variant — `debug`, or `<flavor>Debug` (e.g. `devDebug`) when flavored. Reads the
    *  first product flavor off the `android` extension reflectively (no AGP compile dependency); iterating the


### PR DESCRIPTION
### 🎯 Goal
Let a single-module Compose Multiplatform app — KMP and `com.android.application` applied to the same module, the default structure from the JetBrains KMP wizard — render thumbnails from its own linked resources. Fixes #3.

### 🛠 Implementation details
`findConsumingAndroidApp` explicitly excluded the module itself (`candidate.path != module.path`), so for this module shape the KMP render found no consumer, warned

```
navgraph: thumbnails for KMP module ':composeApp' need a consuming com.android.application's
linked resources, but none was found in this build. The graph still generates; thumbnails are skipped.
```

…about a module that *is* the application, and every Layoutlib render failed with `no result`. An application module links its own full R closure and `.ap_`, so it is its own resource consumer: return it before scanning sibling projects. The existing `wireKmpConsumerResources` globs (`compile_and_runtime*r_class_jar`, `linked_resources_binary_format`, merged assets) all resolve in an application module's own build directory, so the rest of the wiring works unchanged. Multi-module setups keep the existing sibling scan.

### ✍️ Explain examples
Single-module CMP app (`androidTarget()` + iOS, `com.android.application` on the module, Kotlin 2.3.21 / AGP 8.13.1): before, the warning above plus `layoutlib render failed for '<preview>': no result` for every preview, with only the Robolectric fallback producing thumbnails. After, the module feeds its own `debug` linked resources to the render:

```
navgraph: KMP module ':composeApp' renders thumbnails via ':composeApp' (debug) resources.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)