### PR TITLE
Add navgraph { robolectricApplication } to override the Application the Robolectric render boots

### DIFF
--- a/compose-nav-graph-gradle/src/main/kotlin/com/github/skydoves/navgraph/gradle/NavGraphExtension.kt
+++ b/compose-nav-graph-gradle/src/main/kotlin/com/github/skydoves/navgraph/gradle/NavGraphExtension.kt
@@ -57,6 +57,16 @@ public abstract class NavGraphExtension {
   public abstract val renderBackend: Property<RenderBackend>
 
   /**
+   * The fully-qualified name of the `android.app.Application` class the **Robolectric** render boots, e.g.
+   * `"com.example.RenderApplication"` (default blank — the consumer's real Application from the merged manifest).
+   * Robolectric runs the real `Application.onCreate`, which crashes the render when it initializes SDKs that
+   * need a device or Play services (billing, push, analytics, …). Point this at a minimal test-only Application
+   * (typically in the unit-test source set, doing at most DI setup) to render previews without that init. Emitted
+   * as `@Config(application = …)` on the generated render test; sdk/qualifiers stay inherited from the base class.
+   */
+  public abstract val robolectricApplication: Property<String>
+
+  /**
    * The Android **variant** to extract from, e.g. `"debug"` (default) or, for a flavored app/library,
    * `"demoDebug"`. Blank (the default) means *auto-detect* the first `…DebugKotlin` KSP variant — so a flavored
    * project usually just works without setting this. Set it only to pin a specific flavor's graph. Ignored for

--- a/compose-nav-graph-gradle/src/main/kotlin/com/github/skydoves/navgraph/gradle/NavGraphGradlePlugin.kt
+++ b/compose-nav-graph-gradle/src/main/kotlin/com/github/skydoves/navgraph/gradle/NavGraphGradlePlugin.kt
@@ -52,6 +52,7 @@ public class NavGraphGradlePlugin : Plugin<Project> {
       ext.allowMissingBaseline.convention(false)
       ext.renderThumbnails.convention(true)
       ext.renderBackend.convention(RenderBackend.AUTO)
+      ext.robolectricApplication.convention("")
       ext.variant.convention("")
       ext.autoDependencies.convention(true)
       ext.aggregate.convention(true)
@@ -396,7 +397,7 @@ public class NavGraphGradlePlugin : Plugin<Project> {
         }
       }
       val roboAnchors = if (roboSpecs.isNotEmpty()) {
-        wireRobolectric(this, kspTask, roboSpecs, variant, kmp)
+        wireRobolectric(this, kspTask, roboSpecs, variant, kmp, ext.robolectricApplication.get())
       } else {
         emptyMap()
       }
@@ -634,6 +635,7 @@ public class NavGraphGradlePlugin : Plugin<Project> {
     specs: List<RoboSpec>,
     variant: String?,
     kmp: Boolean,
+    robolectricApplication: String,
   ): Map<String, TaskProvider<*>> {
     with(project) {
       // The variant whose unit-test compilation hosts the render: the resolved Android variant for plain-Android;
@@ -662,7 +664,7 @@ public class NavGraphGradlePlugin : Plugin<Project> {
       }
 
       val genDir = layout.buildDirectory.dir("generated/navgraph/robolectric").get().asFile
-      writeRobolectricTest(genDir)
+      writeRobolectricTest(genDir, robolectricApplication)
       addKotlinSrcDir(this, testSourceSets, genDir)
 
       // The render runs INSIDE the consumer's own `test<Variant>UnitTest` (an AGP `AndroidUnitTest`): only AGP
@@ -985,17 +987,29 @@ public class NavGraphGradlePlugin : Plugin<Project> {
 
   /** Write the one-line `NavGraphRobolectricRenderTest` subclass (idempotent — only when missing/changed, so it
    *  never needlessly invalidates the unit-test compilation). JUnit discovers it; `@RunWith`/`@Config` are
-   *  inherited from [com.github.skydoves.navgraph.testing.NavPreviewRenderTestBase]. */
-  private fun writeRobolectricTest(genDir: File) {
+   *  inherited from [com.github.skydoves.navgraph.testing.NavPreviewRenderTestBase]. A non-blank
+   *  [robolectricApplication] (`navgraph { robolectricApplication }`) is emitted as `@Config(application = …)` on
+   *  the subclass — Robolectric overlays class-hierarchy configs per field, so sdk/qualifiers stay inherited. */
+  private fun writeRobolectricTest(genDir: File, robolectricApplication: String) {
     val pkgDir = File(genDir, "com/skydoves/navgraph/generated").apply { mkdirs() }
     val file = File(pkgDir, "NavGraphRobolectricRenderTest.kt")
+    val configImport = if (robolectricApplication.isNotBlank()) {
+      "\nimport org.robolectric.annotation.Config"
+    } else {
+      ""
+    }
+    val configAnnotation = if (robolectricApplication.isNotBlank()) {
+      "@Config(application = $robolectricApplication::class)\n"
+    } else {
+      ""
+    }
     val content =
       """
       |package com.github.skydoves.navgraph.generated
       |
-      |import com.github.skydoves.navgraph.testing.NavPreviewRenderTestBase
+      |import com.github.skydoves.navgraph.testing.NavPreviewRenderTestBase$configImport
       |
-      |internal class NavGraphRobolectricRenderTest : NavPreviewRenderTestBase()
+      |${configAnnotation}internal class NavGraphRobolectricRenderTest : NavPreviewRenderTestBase()
       |
       """.trimMargin()
     if (!file.isFile || file.readText() != content) file.writeText(content)

--- a/docs/gradle-plugin/configuration.md
+++ b/docs/gradle-plugin/configuration.md
@@ -6,6 +6,7 @@ The Gradle plugin is configured through the `navgraph { }` block in your module'
 navgraph {
     renderThumbnails.set(true)  // default
     renderBackend.set(RenderBackend.AUTO)  // default
+    robolectricApplication.set("")  // default: the app's real Application
     variant.set("")  // default: auto detect
     autoDependencies.set(true)  // default
     aggregate.set(true)  // default
@@ -51,6 +52,25 @@ navgraph {
     renderBackend.set(RenderBackend.ROBOLECTRIC)
 }
 ```
+
+## `robolectricApplication`
+
+**Type:** `String` · **Default:** `""` (the app's real `Application`)
+
+The fully qualified name of the `Application` class the **Robolectric** render boots. By default Robolectric runs your real `Application.onCreate`, which crashes the render when it initializes SDKs that need a device or Play services (billing, push, analytics). Point this at a minimal test only `Application` — typically in the unit test source set, doing at most DI setup — to render previews without that init:
+
+```kotlin
+navgraph {
+    robolectricApplication.set("com.example.app.RenderApplication")
+}
+```
+
+```kotlin
+// src/test/kotlin (or src/androidUnitTest/kotlin for KMP)
+class RenderApplication : Application()
+```
+
+The value is emitted as `@Config(application = …)` on the generated render test; the sdk and qualifiers stay inherited from the base test class.
 
 ## `variant`
 


### PR DESCRIPTION
### 🎯 Goal
Let consumers point the Robolectric render at a minimal test-only `Application`, so apps that initialize device-/Play-services-backed SDKs in `Application.onCreate` can render thumbnails at all. Fixes #2.

### 🛠 Implementation details
The generated `NavGraphRobolectricRenderTest` runs under the consumer's real `Application` from the merged manifest. Real apps commonly initialize billing/push/analytics SDKs in `onCreate` — RevenueCat in the linked issue — which throws under Robolectric before any preview composes, failing every render.

New `NavGraphExtension.robolectricApplication` (`Property<String>`, default `""` = today's behavior) takes the FQCN of an `Application` class and is emitted as `@Config(application = …)` on the generated test subclass. Robolectric overlays class-hierarchy configs per field, so the base class's `sdk`/`qualifiers` stay inherited. The value is read in `wire`'s `afterEvaluate`, same as the other extension properties, and the generated-file idempotence check picks up changes to it. Also documented on the `configuration.md` docs page.

### ✍️ Explain examples
```kotlin
// build.gradle.kts
navgraph {
    robolectricApplication.set("com.example.app.RenderApplication")
}
```

```kotlin
// src/androidUnitTest/kotlin (KMP) or src/test/kotlin
class RenderApplication : Application()  // at most DI setup, no SDK init
```

Generated test:

```kotlin
package com.github.skydoves.navgraph.generated

import com.github.skydoves.navgraph.testing.NavPreviewRenderTestBase
import org.robolectric.annotation.Config

@Config(application = com.example.app.RenderApplication::class)
internal class NavGraphRobolectricRenderTest : NavPreviewRenderTestBase()
```

Verified the equivalent `application=` override (via `robolectric.properties`) unblocks the render on a real app whose `onCreate` configures RevenueCat — this knob makes that first-class without a properties file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)