### PR TITLE
Support Preview locale metadata in thumbnail rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **`@Preview(locale = …)` support for thumbnails** ([#7](https://github.com/skydoves/compose-nav-graph/issues/7)): the KSP processor now captures the preview's locale qualifier (declared directly or via a multipreview meta-annotation) into the manifest, and both render backends apply it (Layoutlib through the renderer's preview params, Robolectric through a composition-scoped configuration-context override), so localized previews render with the same resources Android Studio shows.
+
+### Fixed
+- The generated `navgraph.version` resource (which pins the auto-wired `compose-nav-graph-annotations` / `compose-nav-graph-ksp` / `compose-nav-graph-testing` versions) is regenerated when `VERSION_NAME` changes instead of staying stale.
+
 ## [0.1.0] - 2026-06-01
 
 ### Added

--- a/compose-nav-graph-annotations/api/android/compose-nav-graph-annotations.api
+++ b/compose-nav-graph-annotations/api/android/compose-nav-graph-annotations.api
@@ -220,17 +220,19 @@ public final class com/github/skydoves/navgraph/model/NavPreviewParam$Companion 
 
 public final class com/github/skydoves/navgraph/model/NavPreviewRef {
 	public static final field Companion Lcom/github/skydoves/navgraph/model/NavPreviewRef$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Z)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ZLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/util/List;
 	public final fun component5 ()Ljava/lang/String;
 	public final fun component6 ()Z
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Z)Lcom/github/skydoves/navgraph/model/NavPreviewRef;
-	public static synthetic fun copy$default (Lcom/github/skydoves/navgraph/model/NavPreviewRef;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ZILjava/lang/Object;)Lcom/github/skydoves/navgraph/model/NavPreviewRef;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ZLjava/lang/String;)Lcom/github/skydoves/navgraph/model/NavPreviewRef;
+	public static synthetic fun copy$default (Lcom/github/skydoves/navgraph/model/NavPreviewRef;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ZLjava/lang/String;ILjava/lang/Object;)Lcom/github/skydoves/navgraph/model/NavPreviewRef;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLocale ()Ljava/lang/String;
 	public final fun getPreviewFqn ()Ljava/lang/String;
 	public final fun getPreviewMethodFqn ()Ljava/lang/String;
 	public final fun getPreviewName ()Ljava/lang/String;

--- a/compose-nav-graph-annotations/api/jvm/compose-nav-graph-annotations.api
+++ b/compose-nav-graph-annotations/api/jvm/compose-nav-graph-annotations.api
@@ -220,17 +220,19 @@ public final class com/github/skydoves/navgraph/model/NavPreviewParam$Companion 
 
 public final class com/github/skydoves/navgraph/model/NavPreviewRef {
 	public static final field Companion Lcom/github/skydoves/navgraph/model/NavPreviewRef$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Z)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ZLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/util/List;
 	public final fun component5 ()Ljava/lang/String;
 	public final fun component6 ()Z
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Z)Lcom/github/skydoves/navgraph/model/NavPreviewRef;
-	public static synthetic fun copy$default (Lcom/github/skydoves/navgraph/model/NavPreviewRef;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ZILjava/lang/Object;)Lcom/github/skydoves/navgraph/model/NavPreviewRef;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ZLjava/lang/String;)Lcom/github/skydoves/navgraph/model/NavPreviewRef;
+	public static synthetic fun copy$default (Lcom/github/skydoves/navgraph/model/NavPreviewRef;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ZLjava/lang/String;ILjava/lang/Object;)Lcom/github/skydoves/navgraph/model/NavPreviewRef;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLocale ()Ljava/lang/String;
 	public final fun getPreviewFqn ()Ljava/lang/String;
 	public final fun getPreviewMethodFqn ()Ljava/lang/String;
 	public final fun getPreviewName ()Ljava/lang/String;

--- a/compose-nav-graph-annotations/src/commonMain/kotlin/com/github/skydoves/navgraph/model/NavGraphModels.kt
+++ b/compose-nav-graph-annotations/src/commonMain/kotlin/com/github/skydoves/navgraph/model/NavGraphModels.kt
@@ -126,6 +126,10 @@ public data class NavArg(
  *   The device-free renderer needs each provider to instantiate the composable's sample value — without them a
  *   parameterized `@NavPreview` (very common in real apps) can't render and yields a blank/failed thumbnail.
  * @property primary whether this is the canonical thumbnail for the route (`@NavPreview.primary`).
+ * @property locale the `@Preview(locale = …)` resource qualifier (e.g. `"ko"`, `"fr-rFR"`) the function's
+ *   `@Preview` declares, directly or via a multipreview meta-annotation; null when none is declared. Both
+ *   render backends apply it so the thumbnail matches what Android Studio's preview shows. Additive since
+ *   schema 1 (absent in older manifests → null).
  */
 @Serializable
 public data class NavPreviewRef(
@@ -135,6 +139,7 @@ public data class NavPreviewRef(
   val previewParameters: List<NavPreviewParam> = emptyList(),
   val thumbnail: String? = null,
   val primary: Boolean = false,
+  val locale: String? = null,
 )
 
 /**

--- a/compose-nav-graph-gradle/build.gradle.kts
+++ b/compose-nav-graph-gradle/build.gradle.kts
@@ -37,6 +37,9 @@ tasks.withType<Test>().configureEach { useJUnit() }
 val generateNavGraphVersion = tasks.register("generateNavGraphVersion") {
   val outDir = layout.buildDirectory.dir("generated/navgraphversion")
   val versionValue = version.toString()
+  // Without this input the task stays UP-TO-DATE across a VERSION_NAME bump, leaving a stale
+  // resource — consumers would then auto-wire the previous release's artifacts.
+  inputs.property("version", versionValue)
   outputs.dir(outDir)
   doLast {
     outDir.get().file("navgraph.version").asFile.apply {

--- a/compose-nav-graph-gradle/gradle.properties
+++ b/compose-nav-graph-gradle/gradle.properties
@@ -1,7 +1,7 @@
 # compose-nav-graph-gradle is a standalone (included) build, so it carries its own publishing coordinates
 # rather than inheriting the root gradle.properties.
 GROUP=com.github.skydoves
-VERSION_NAME=0.1.0
+VERSION_NAME=0.1.1-SNAPSHOT
 
 POM_NAME=Compose Navigation Graph Gradle Plugin
 POM_ARTIFACT_ID=compose-nav-graph-gradle

--- a/compose-nav-graph-gradle/src/main/kotlin/com/github/skydoves/navgraph/gradle/LayoutlibRenderTask.kt
+++ b/compose-nav-graph-gradle/src/main/kotlin/com/github/skydoves/navgraph/gradle/LayoutlibRenderTask.kt
@@ -114,6 +114,7 @@ public abstract class LayoutlibRenderTask : DefaultTask() {
     val methodFqn: String,
     val id: String,
     val params: List<HPreviewParam>,
+    val locale: String?,
   )
 
   @TaskAction
@@ -135,7 +136,10 @@ public abstract class LayoutlibRenderTask : DefaultTask() {
             )
           } else {
             add(
-              Shot(node.id, pv.previewName, pv.primary, method, "nav${i++}", pv.previewParameters),
+              Shot(
+                node.id, pv.previewName, pv.primary, method, "nav${i++}",
+                pv.previewParameters, pv.locale,
+              ),
             )
           }
         }
@@ -205,6 +209,9 @@ public abstract class LayoutlibRenderTask : DefaultTask() {
             putJsonObject("previewParams") {
               put("apiLevel", apiLevel.get())
               put("device", PREVIEW_DEVICE)
+              // The @Preview(locale = …) qualifier, extracted by KSP (a multipreview's meta-annotation isn't
+              // visible to the renderer itself, so it must be passed explicitly).
+              s.locale?.let { put("locale", it) }
             }
             put("previewId", s.id)
           }

--- a/compose-nav-graph-gradle/src/main/kotlin/com/github/skydoves/navgraph/gradle/NavManifest.kt
+++ b/compose-nav-graph-gradle/src/main/kotlin/com/github/skydoves/navgraph/gradle/NavManifest.kt
@@ -65,6 +65,7 @@ internal data class HPreview(
   val previewParameters: List<HPreviewParam> = emptyList(),
   val thumbnail: String? = null,
   val primary: Boolean = false,
+  val locale: String? = null,
 )
 
 internal data class HPreviewParam(val name: String = "", val provider: String = "")
@@ -107,6 +108,7 @@ internal fun parseGraph(text: String): HGraph {
           },
           thumbnail = po.str("thumbnail"),
           primary = po.bool("primary"),
+          locale = po.str("locale"),
         )
       },
       start = o.bool("start"),

--- a/compose-nav-graph-gradle/src/main/kotlin/com/github/skydoves/navgraph/gradle/RobolectricRenderListTask.kt
+++ b/compose-nav-graph-gradle/src/main/kotlin/com/github/skydoves/navgraph/gradle/RobolectricRenderListTask.kt
@@ -29,7 +29,7 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.work.DisableCachingByDefault
 
 /**
- * Writes the TSV render-list (`methodFqn\tnodeId\tpreviewName\tprimary`, one preview per line) that the
+ * Writes the TSV render-list (`methodFqn\tnodeId\tpreviewName\tprimary[\tlocale]`, one preview per line) that the
  * generated `NavGraphRobolectricRenderTest` reads via the `navgraph.renderList` system property. In `ROBOLECTRIC` mode
  * every `@NavPreview` is listed; in `AUTO` mode only the previews Layoutlib **failed** to render are listed —
  * derived from the Layoutlib `results.json` ([readLayoutlibResults] + [isLayoutlibSuccess]), the single source
@@ -81,6 +81,7 @@ public abstract class RobolectricRenderListTask : DefaultTask() {
       val primary: Boolean,
       val methodFqn: String,
       val id: String,
+      val locale: String?,
     )
     val shots = buildList {
       var i = 0
@@ -88,7 +89,7 @@ public abstract class RobolectricRenderListTask : DefaultTask() {
         node.previews.forEach { pv ->
           val method = pv.previewMethodFqn
           if (!method.isNullOrBlank()) {
-            add(Shot(node.id, pv.previewName, pv.primary, method, "nav${i++}"))
+            add(Shot(node.id, pv.previewName, pv.primary, method, "nav${i++}", pv.locale))
           }
         }
       }
@@ -115,9 +116,14 @@ public abstract class RobolectricRenderListTask : DefaultTask() {
 
     val out = renderList.get().asFile
     out.parentFile.mkdirs()
+    // TSV fields are TRAILING-additive only: NavPreviewRenderer in compose-nav-graph-testing parses this
+    // line format, and the plugin auto-wires that artifact at its own version, so both sides move in step.
+    // The locale field is emitted only when present, keeping locale-less lines byte-identical to the
+    // 4-field format an older, explicitly-pinned testing artifact still parses correctly.
     out.writeText(
       selected.joinToString("") { s ->
-        "${s.methodFqn}\t${s.nodeId}\t${s.previewName}\t${s.primary}\n"
+        "${s.methodFqn}\t${s.nodeId}\t${s.previewName}\t${s.primary}" +
+          "${s.locale?.let { "\t$it" }.orEmpty()}\n"
       },
     )
     logger.lifecycle(

--- a/compose-nav-graph-ksp/src/main/kotlin/com/github/skydoves/navgraph/ksp/NavGraphProcessor.kt
+++ b/compose-nav-graph-ksp/src/main/kotlin/com/github/skydoves/navgraph/ksp/NavGraphProcessor.kt
@@ -135,6 +135,7 @@ internal class NavGraphProcessor(
               previewMethodFqn = jvmMethodFqn(fn),
               previewParameters = previewParametersOf(fn),
               primary = ann.boolArg("primary"),
+              locale = previewLocaleOf(fn),
             ),
           )
         }
@@ -324,6 +325,7 @@ internal class NavGraphProcessor(
             previewMethodFqn = method,
             previewParameters = previewParametersOf(fn),
             primary = false,
+            locale = previewLocaleOf(fn),
           )
         }
       // The slug is lossy (two packages/modules differing only by `_` vs `.`/`-`/`:` collapse to one), so append
@@ -372,6 +374,33 @@ internal class NavGraphProcessor(
       val metaDecl = meta.annotationType.resolve().declaration as? KSClassDeclaration
       metaDecl != null && isPreviewAnnotation(metaDecl, visited)
     }
+  }
+
+  /**
+   * The `@Preview(locale = …)` qualifier the function's preview declares, or null. Walks the function's
+   * annotations in declaration order — recursing into multipreview meta-annotations depth-first (same cycle
+   * guard as [isPreviewAnnotation]) — and returns the FIRST non-blank locale found. A function whose
+   * `@Preview`s disagree on locale renders one thumbnail, so one locale has to win, and declaration order is
+   * the deterministic choice (a meta-annotation listed before a direct `@Preview` wins).
+   */
+  private fun previewLocaleOf(fn: KSFunctionDeclaration): String? =
+    firstPreviewLocale(fn.annotations, mutableSetOf())
+
+  private fun firstPreviewLocale(
+    annotations: Sequence<KSAnnotation>,
+    visited: MutableSet<String>,
+  ): String? {
+    for (ann in annotations) {
+      val decl = ann.annotationType.resolve().declaration as? KSClassDeclaration ?: continue
+      val name = decl.qualifiedName?.asString() ?: continue
+      if (name == PREVIEW) {
+        ann.stringArg("locale")?.takeIf(String::isNotBlank)?.let { return it }
+        continue
+      }
+      if (!visited.add(name)) continue
+      firstPreviewLocale(decl.annotations, visited)?.let { return it }
+    }
+    return null
   }
 
   /**

--- a/compose-nav-graph-ksp/src/test/kotlin/com/github/skydoves/navgraph/ksp/NavGraphProcessorTest.kt
+++ b/compose-nav-graph-ksp/src/test/kotlin/com/github/skydoves/navgraph/ksp/NavGraphProcessorTest.kt
@@ -316,6 +316,56 @@ class NavGraphProcessorTest {
     assertEquals("com.app.ProfilePreview", preview.previewFqn)
     assertEquals("com.app.PreviewsKt.ProfilePreview", preview.previewMethodFqn)
     assertTrue(preview.primary)
+    assertEquals("a preview without @Preview(locale) carries none", null, preview.locale)
+  }
+
+  @Test
+  fun navPreview_carriesDirectPreviewLocale() {
+    val graph = compileNavGraph(
+      SourceFile.kotlin(
+        "Previews.kt",
+        """
+        package com.app
+        import androidx.compose.ui.tooling.preview.Preview
+        import androidx.navigation3.runtime.NavKey
+        import com.github.skydoves.navgraph.annotations.NavPreview
+        class Profile : NavKey
+        @Preview(locale = "ko")
+        @NavPreview(route = Profile::class, primary = true)
+        fun ProfilePreview() {}
+        """.trimIndent(),
+      ),
+      PREVIEW_STUB,
+    )
+
+    assertEquals("ko", graph.node("Profile").previews.single().locale)
+  }
+
+  @Test
+  fun navPreview_carriesLocaleFromMultipreviewMetaAnnotation() {
+    val graph = compileNavGraph(
+      SourceFile.kotlin(
+        "Previews.kt",
+        """
+        package com.app
+        import androidx.compose.ui.tooling.preview.Preview
+        import androidx.navigation3.runtime.NavKey
+        import com.github.skydoves.navgraph.annotations.NavPreview
+
+        @Preview(name = "Light", locale = "fr-rFR")
+        @Preview(name = "Dark", locale = "fr-rFR")
+        annotation class DevicePreview
+
+        class Profile : NavKey
+        @DevicePreview
+        @NavPreview(route = Profile::class, primary = true)
+        fun ProfilePreview() {}
+        """.trimIndent(),
+      ),
+      PREVIEW_STUB,
+    )
+
+    assertEquals("fr-rFR", graph.node("Profile").previews.single().locale)
   }
 
   @Test

--- a/compose-nav-graph-ksp/src/test/kotlin/com/github/skydoves/navgraph/ksp/NavGraphTestSupport.kt
+++ b/compose-nav-graph-ksp/src/test/kotlin/com/github/skydoves/navgraph/ksp/NavGraphTestSupport.kt
@@ -34,6 +34,20 @@ private val NAV_KEY_STUB = SourceFile.kotlin(
   """.trimIndent(),
 )
 
+/** Mirrors androidx's `@Preview` FQN + the params the processor reads — the real artifact isn't on the
+ *  test classpath, and KSP matches annotations by qualified name only. */
+internal val PREVIEW_STUB = SourceFile.kotlin(
+  "Preview.kt",
+  """
+  package androidx.compose.ui.tooling.preview
+  @Repeatable
+  annotation class Preview(
+    val name: String = "",
+    val locale: String = "",
+  )
+  """.trimIndent(),
+)
+
 private val DECODER = Json { ignoreUnknownKeys = true }
 
 internal fun compileNavGraph(

--- a/compose-nav-graph-testing/api/compose-nav-graph-testing.api
+++ b/compose-nav-graph-testing/api/compose-nav-graph-testing.api
@@ -12,6 +12,6 @@ public final class com/github/skydoves/navgraph/testing/NavPreviewRenderer {
 }
 
 public final class com/github/skydoves/navgraph/testing/NavPreviewWrapperKt {
-	public static final fun NavPreviewWrapper (Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+	public static final fun NavPreviewWrapper (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 }
 

--- a/compose-nav-graph-testing/src/main/kotlin/com/github/skydoves/navgraph/testing/NavPreviewRenderer.kt
+++ b/compose-nav-graph-testing/src/main/kotlin/com/github/skydoves/navgraph/testing/NavPreviewRenderer.kt
@@ -59,7 +59,7 @@ public object NavPreviewRenderer {
       val entry = current
       if (entry != null) {
         key(entry.methodFqn) {
-          NavPreviewWrapper {
+          NavPreviewWrapper(locale = entry.locale) {
             ComposableInvoker.invokeComposable(
               entry.methodFqn.substringBeforeLast('.'),
               entry.methodFqn.substringAfterLast('.'),
@@ -101,8 +101,9 @@ public object NavPreviewRenderer {
     }
   }
 
-  /** Read one render job's TSV (`methodFqn\tnodeId\tpreviewName\tprimary`, one preview per line) plus its output
-   *  thumbs dir + preview index from the given system properties; an absent/blank list or dir yields no entries
+  /** Read one render job's TSV (`methodFqn\tnodeId\tpreviewName\tprimary[\tlocale]`, one preview per line —
+   *  fields are trailing-additive; a 4-field line from an older plugin still parses) plus its output thumbs
+   *  dir + preview index from the given system properties; an absent/blank list or dir yields no entries
    *  (the job is skipped). */
   private fun readJob(listProp: String, thumbsProp: String, indexProp: String): List<RenderEntry> {
     val listPath = System.getProperty(listProp)?.takeIf { it.isNotBlank() } ?: return emptyList()
@@ -112,9 +113,9 @@ public object NavPreviewRenderer {
       ?: return emptyList()
     return File(listPath).takeIf { it.isFile }?.readLines().orEmpty().mapNotNull { line ->
       if (line.isBlank()) return@mapNotNull null
-      val parts = line.split("\t", limit = 4)
+      val parts = line.split("\t", limit = 5)
       if (parts.size < 4) return@mapNotNull null
-      RenderEntry(parts[0], parts[1], parts[2], parts[3], thumbs, index)
+      RenderEntry(parts[0], parts[1], parts[2], parts[3], parts.getOrNull(4), thumbs, index)
     }
   }
 
@@ -123,6 +124,7 @@ public object NavPreviewRenderer {
     val nodeId: String,
     val previewName: String,
     val primary: String,
+    val locale: String?,
     val thumbsDir: File,
     val previewIndex: File,
   )

--- a/compose-nav-graph-testing/src/main/kotlin/com/github/skydoves/navgraph/testing/NavPreviewWrapper.kt
+++ b/compose-nav-graph-testing/src/main/kotlin/com/github/skydoves/navgraph/testing/NavPreviewWrapper.kt
@@ -15,13 +15,21 @@
  */
 package com.github.skydoves.navgraph.testing
 
+import android.content.res.Configuration
+import android.os.LocaleList
+import android.view.View
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.LayoutDirection
 import org.jetbrains.compose.resources.PreviewContextConfigurationEffect
 
 @Composable
-public fun NavPreviewWrapper(content: @Composable () -> Unit) {
+public fun NavPreviewWrapper(locale: String? = null, content: @Composable () -> Unit) {
   CompositionLocalProvider(LocalInspectionMode provides true) {
     // PreviewContextConfigurationEffect wires Compose-Multiplatform's resource context so `Res.*` resolve in a
     // preview. It lives in `components-resources`, a compileOnly dependency: present for a CMP consumer, ABSENT for
@@ -30,8 +38,52 @@ public fun NavPreviewWrapper(content: @Composable () -> Unit) {
     if (CMP_RESOURCES_ON_CLASSPATH) {
       PreviewContextConfigurationEffect()
     }
+    if (locale.isNullOrBlank()) {
+      content()
+    } else {
+      LocalizedPreview(locale, content)
+    }
+  }
+}
+
+/**
+ * Applies a `@Preview(locale = …)` qualifier the same way Android Studio's preview does: a
+ * configuration-context override scoped to the composition — NOT a system-wide qualifier change, which
+ * (under Robolectric) recreates the host Activity and blanks the captured frame. String and drawable
+ * resources below this point resolve against the localized configuration.
+ */
+@Composable
+private fun LocalizedPreview(locale: String, content: @Composable () -> Unit) {
+  val baseContext = LocalContext.current
+  val baseConfiguration = LocalConfiguration.current
+  val configuration = remember(locale, baseConfiguration) {
+    // setLocales also derives the configuration's layout direction from the locale.
+    Configuration(baseConfiguration).apply {
+      setLocales(LocaleList.forLanguageTags(localeTag(locale)))
+    }
+  }
+  val localizedContext = remember(configuration) {
+    baseContext.createConfigurationContext(configuration)
+  }
+  val layoutDirection = if (configuration.layoutDirection == View.LAYOUT_DIRECTION_RTL) {
+    LayoutDirection.Rtl
+  } else {
+    LayoutDirection.Ltr
+  }
+  CompositionLocalProvider(
+    LocalContext provides localizedContext,
+    LocalConfiguration provides configuration,
+    LocalLayoutDirection provides layoutDirection,
+  ) {
     content()
   }
+}
+
+/** `@Preview(locale)` accepts resource-qualifier syntax — map it to a BCP-47 tag:
+ *  `"ko"` → `"ko"`, `"fr-rFR"` → `"fr-FR"`, `"b+es+419"` → `"es-419"`. */
+private fun localeTag(qualifier: String): String = when {
+  qualifier.startsWith("b+") -> qualifier.removePrefix("b+").replace('+', '-')
+  else -> qualifier.replace("-r", "-")
 }
 
 /** Whether Compose-Multiplatform's `components-resources` is on the runtime classpath (it is a compileOnly

--- a/docs/gradle-plugin/annotations.md
+++ b/docs/gradle-plugin/annotations.md
@@ -70,6 +70,12 @@ fun ProfileScreenPreview() {
 
 Set `primary = true` (default `false`) on the preview you want as the canonical thumbnail. When a route has several previews (light/dark, empty/loaded), exactly one of them should be `primary`.
 
+The thumbnail also honors the preview's **`@Preview(locale = …)`** qualifier, declared directly or through a
+multipreview meta-annotation (a custom `@DevicePreview` carrying `@Preview(locale = "ko")`, for example). Both
+render backends apply it, so a localized preview renders with the same string and drawable resources Android
+Studio's preview would show. When a function's `@Preview`s declare different locales, the first one wins (one
+function renders one thumbnail).
+
 !!! note "Why a separate preview function"
 
     The renderer reads `@NavPreview` via reflection on the discovered preview at render time, so it's `RUNTIME`-retained. You annotate the **preview** (not the screen) so the toolkit renders the screen exactly as you'd preview it in Android Studio, with its sample/fake state wired in. `@PreviewParameter` providers are honored.

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ android.nonTransitiveRClass=true
 
 # --- Maven coordinates (vanniktech publish) ---
 GROUP=com.github.skydoves
-VERSION_NAME=0.1.0
+VERSION_NAME=0.1.1-SNAPSHOT
 
 POM_URL=https://github.com/skydoves/compose-nav-graph/
 POM_SCM_URL=https://github.com/skydoves/compose-nav-graph/

--- a/samples/sample/src/main/kotlin/com/github/skydoves/navgraph/sample/SettingsScreen.kt
+++ b/samples/sample/src/main/kotlin/com/github/skydoves/navgraph/sample/SettingsScreen.kt
@@ -61,6 +61,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -398,4 +399,20 @@ private val settingsSections: List<SettingsSection> = listOf(
 @Composable
 internal fun SettingsScreenPreview() {
   NavSampleTheme { SettingsScreen() }
+}
+
+// Renders with Korean resources (values-ko/) on both backends; see @Preview(locale) support.
+@NavPreview(route = Settings::class)
+@Preview(showBackground = true, locale = "ko")
+@Composable
+internal fun SettingsScreenKoreanPreview() {
+  NavSampleTheme {
+    Surface(color = MaterialTheme.colorScheme.surfaceVariant) {
+      Text(
+        text = stringResource(R.string.settings_greeting),
+        style = MaterialTheme.typography.headlineMedium,
+        modifier = Modifier.padding(32.dp),
+      )
+    }
+  }
 }

--- a/samples/sample/src/main/res/values-ko/strings.xml
+++ b/samples/sample/src/main/res/values-ko/strings.xml
@@ -15,6 +15,5 @@
      limitations under the License.
 -->
 <resources>
-    <string name="app_name">navgraph sample</string>
-    <string name="settings_greeting">Settings</string>
+    <string name="settings_greeting">설정</string>
 </resources>


### PR DESCRIPTION
### 🎯 Goal
Render nav graph and preview gallery thumbnails with the locale the preview declares, so localized apps get thumbnails matching what Android Studio's preview shows. Fixes #7.

### 🛠 Implementation details
- **KSP** (`compose-nav-graph-ksp`): `previewLocaleOf` walks the `@NavPreview` function's annotations in declaration order, recursing into multipreview meta-annotations with the same cycle guard as the gallery discovery, and records the first non-blank `@Preview(locale = …)` into the manifest. Applies to both the nav graph and the preview gallery entries.
- **Schema** (`compose-nav-graph-annotations`): additive `NavPreviewRef.locale: String? = null` (schema stays v1; older manifests decode unchanged; api dumps regenerated).
- **Layoutlib backend**: the qualifier is passed through the renderer's `previewParams.locale`, the same key Android Studio's annotation carries (a multipreview's meta-annotation isn't visible to the renderer itself, so it must be passed explicitly).
- **Robolectric backend**: the render-list TSV gains a trailing-additive `locale` field (emitted only when present, so locale-less lines stay byte-identical to the old 4-field format), and `NavPreviewWrapper` applies it as a composition-scoped configuration-context override with the matching `LocalLayoutDirection`. A `RuntimeEnvironment.setQualifiers` approach was rejected: the configuration change recreates the host Activity and blanks the captured frame.
- **Build fix**: the generated `navgraph.version` resource now declares its version as a task input; previously it stayed UP-TO-DATE across a `VERSION_NAME` bump, making consumers auto-wire the previous release's artifacts.

### ✍️ Explain examples
```kotlin
@Preview(locale = "ko")
@NavPreview(route = Settings::class)
@Composable
fun SettingsScreenKoreanPreview() { /* … */ }
```
Verified end to end on `samples/sample` (new `SettingsScreenKoreanPreview` + `values-ko/` resources): both backends render the Korean string (설정), confirmed at the pixel level. Multipreview meta-annotations (`@DevicePreview` carrying `@Preview(locale = "ko")`) are covered by new KSP unit tests.
