### PR TITLE
Add an article on the README and docs

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
 github: skydoves
-custom: ["https://www.android.skydoves.me/", "https://kotlin.skydoves.me/", "https://github.com/doveletter"]
+custom: ["https://android.skydoves.me/", "https://kotlin.skydoves.me/", "https://howcomposeworks.com/", "https://github.com/doveletter"]

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ The sponsors listed below made it possible for this project to be released as op
 
 **[CodeRabbit](https://coderabbit.link/Jaewoong)** is an AI-powered code review platform that integrates directly into pull-request workflows and IDEs, examining code changes in context and suggesting improvements.
 
+## 📖 Article
+
+For a guided tour of the whole toolkit, read the walkthrough article **[Compose Navigation Graph: Visualize Your Entire App Flow in Android Studio](https://doveletter.dev/articles/compose-nav-graph-plugin)**, which goes from annotating your first screen to validating navigation in pull requests.
+
 ## Compose Navigation Graph Plugin
 
 The Compose Navigation Graph IntelliJ plugin brings your app's **whole navigation flow** directly into Android Studio

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,10 @@ It follows the same "make the invisible visible" idea as [Compose Stability Anal
 
 ![NavGraph Graph tool window](assets/plugin-nav-graph.png)
 
+!!! tip "New here? Start with the walkthrough"
+
+    For a guided tour of the whole toolkit, read **[Compose Navigation Graph: Visualize Your Entire App Flow in Android Studio](https://doveletter.dev/articles/compose-nav-graph-plugin)** on Dove Letter.
+
 !!! tip "Set everything up in one shot with AI"
 
     Throw **[plugin-agent-guides.md](https://github.com/skydoves/compose-nav-graph/blob/main/plugin-agent-guides.md)** at your LLM (Claude Code, Cursor, Gemini CLI, ...) as-is, and it will apply the Gradle plugin, annotate your screens, and generate your first graph for you.

--- a/docs/more-plugins.md
+++ b/docs/more-plugins.md
@@ -24,4 +24,5 @@ same Gradle-plus-IDE architecture this toolkit uses:
 ## Dove Letter
 
 **[Dove Letter](https://doveletter.dev/)** is a daily subscription where you can learn, discuss, and share new
-knowledge about Android, Kotlin, Jetpack Compose, and careers as a developer.
+knowledge about Android, Kotlin, Jetpack Compose, and careers as a developer. It also hosts the introductory walkthrough
+for this plugin: **[Compose Navigation Graph: Visualize Your Entire App Flow in Android Studio](https://doveletter.dev/articles/compose-nav-graph-plugin)**.


### PR DESCRIPTION
Add an article on the README and docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an "Article" section linking to a comprehensive walkthrough guide about Compose Navigation Graph and visualizing app flow
  * Added a "Getting started" tip section to the documentation homepage directing new users to the walkthrough article
  * Enhanced plugin documentation with enriched subscription and introduction links

* **Chores**
  * Updated project funding configuration links

<!-- end of auto-generated comment: release notes by coderabbit.ai -->