### PR TITLE
Honor @Preview size config in NavGraph thumbnails (#13)

### DIFF
--- a/compose-nav-graph-annotations/api/android/compose-nav-graph-annotations.api
+++ b/compose-nav-graph-annotations/api/android/compose-nav-graph-annotations.api
@@ -220,18 +220,23 @@ public final class com/github/skydoves/navgraph/model/NavPreviewParam$Companion 
 
 public final class com/github/skydoves/navgraph/model/NavPreviewRef {
 	public static final field Companion Lcom/github/skydoves/navgraph/model/NavPreviewRef$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ZLjava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/util/List;
 	public final fun component5 ()Ljava/lang/String;
 	public final fun component6 ()Z
 	public final fun component7 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ZLjava/lang/String;)Lcom/github/skydoves/navgraph/model/NavPreviewRef;
-	public static synthetic fun copy$default (Lcom/github/skydoves/navgraph/model/NavPreviewRef;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ZLjava/lang/String;ILjava/lang/Object;)Lcom/github/skydoves/navgraph/model/NavPreviewRef;
+	public final fun component8 ()Ljava/lang/Integer;
+	public final fun component9 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;)Lcom/github/skydoves/navgraph/model/NavPreviewRef;
+	public static synthetic fun copy$default (Lcom/github/skydoves/navgraph/model/NavPreviewRef;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;ILjava/lang/Object;)Lcom/github/skydoves/navgraph/model/NavPreviewRef;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDevice ()Ljava/lang/String;
+	public final fun getHeightDp ()Ljava/lang/Integer;
 	public final fun getLocale ()Ljava/lang/String;
 	public final fun getPreviewFqn ()Ljava/lang/String;
 	public final fun getPreviewMethodFqn ()Ljava/lang/String;
@@ -239,6 +244,7 @@ public final class com/github/skydoves/navgraph/model/NavPreviewRef {
 	public final fun getPreviewParameters ()Ljava/util/List;
 	public final fun getPrimary ()Z
 	public final fun getThumbnail ()Ljava/lang/String;
+	public final fun getWidthDp ()Ljava/lang/Integer;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/compose-nav-graph-annotations/api/jvm/compose-nav-graph-annotations.api
+++ b/compose-nav-graph-annotations/api/jvm/compose-nav-graph-annotations.api
@@ -220,18 +220,23 @@ public final class com/github/skydoves/navgraph/model/NavPreviewParam$Companion 
 
 public final class com/github/skydoves/navgraph/model/NavPreviewRef {
 	public static final field Companion Lcom/github/skydoves/navgraph/model/NavPreviewRef$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ZLjava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/util/List;
 	public final fun component5 ()Ljava/lang/String;
 	public final fun component6 ()Z
 	public final fun component7 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ZLjava/lang/String;)Lcom/github/skydoves/navgraph/model/NavPreviewRef;
-	public static synthetic fun copy$default (Lcom/github/skydoves/navgraph/model/NavPreviewRef;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ZLjava/lang/String;ILjava/lang/Object;)Lcom/github/skydoves/navgraph/model/NavPreviewRef;
+	public final fun component8 ()Ljava/lang/Integer;
+	public final fun component9 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;)Lcom/github/skydoves/navgraph/model/NavPreviewRef;
+	public static synthetic fun copy$default (Lcom/github/skydoves/navgraph/model/NavPreviewRef;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;ILjava/lang/Object;)Lcom/github/skydoves/navgraph/model/NavPreviewRef;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDevice ()Ljava/lang/String;
+	public final fun getHeightDp ()Ljava/lang/Integer;
 	public final fun getLocale ()Ljava/lang/String;
 	public final fun getPreviewFqn ()Ljava/lang/String;
 	public final fun getPreviewMethodFqn ()Ljava/lang/String;
@@ -239,6 +244,7 @@ public final class com/github/skydoves/navgraph/model/NavPreviewRef {
 	public final fun getPreviewParameters ()Ljava/util/List;
 	public final fun getPrimary ()Z
 	public final fun getThumbnail ()Ljava/lang/String;
+	public final fun getWidthDp ()Ljava/lang/Integer;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/compose-nav-graph-annotations/src/commonMain/kotlin/com/github/skydoves/navgraph/model/NavGraphModels.kt
+++ b/compose-nav-graph-annotations/src/commonMain/kotlin/com/github/skydoves/navgraph/model/NavGraphModels.kt
@@ -140,6 +140,9 @@ public data class NavPreviewRef(
   val thumbnail: String? = null,
   val primary: Boolean = false,
   val locale: String? = null,
+  val widthDp: Int? = null,
+  val heightDp: Int? = null,
+  val device: String? = null,
 )
 
 /**

--- a/compose-nav-graph-gradle/src/main/kotlin/com/github/skydoves/navgraph/gradle/LayoutlibRenderTask.kt
+++ b/compose-nav-graph-gradle/src/main/kotlin/com/github/skydoves/navgraph/gradle/LayoutlibRenderTask.kt
@@ -121,6 +121,9 @@ public abstract class LayoutlibRenderTask : DefaultTask() {
     val id: String,
     val params: List<HPreviewParam>,
     val locale: String?,
+    val widthDp: Int?,
+    val heightDp: Int?,
+    val device: String?,
   )
 
   @TaskAction
@@ -150,6 +153,9 @@ public abstract class LayoutlibRenderTask : DefaultTask() {
                 "nav${i++}",
                 pv.previewParameters,
                 pv.locale,
+                pv.widthDp,
+                pv.heightDp,
+                pv.device,
               ),
             )
           }
@@ -219,7 +225,17 @@ public abstract class LayoutlibRenderTask : DefaultTask() {
             // `@DevicePreviews`-annotated preview already carries its own device and renders fine either way.
             putJsonObject("previewParams") {
               put("apiLevel", apiLevel.get())
-              put("device", PREVIEW_DEVICE)
+              // Honor @Preview sizing (#13): an explicit `device` passes through; otherwise widthDp/heightDp
+              // synthesize a device spec (an unset dimension keeps the default 411/891 canvas). The fixed phone
+              // default (above) still applies when the preview declares no size, so unsized lazy layouts stay bounded.
+              put(
+                "device",
+                s.device ?: if (s.widthDp != null || s.heightDp != null) {
+                  "spec:width=${s.widthDp ?: 411}dp,height=${s.heightDp ?: 891}dp,dpi=420"
+                } else {
+                  PREVIEW_DEVICE
+                },
+              )
               // The @Preview(locale = …) qualifier, extracted by KSP (a multipreview's meta-annotation isn't
               // visible to the renderer itself, so it must be passed explicitly).
               s.locale?.let { put("locale", it) }

--- a/compose-nav-graph-gradle/src/main/kotlin/com/github/skydoves/navgraph/gradle/NavManifest.kt
+++ b/compose-nav-graph-gradle/src/main/kotlin/com/github/skydoves/navgraph/gradle/NavManifest.kt
@@ -66,6 +66,9 @@ internal data class HPreview(
   val thumbnail: String? = null,
   val primary: Boolean = false,
   val locale: String? = null,
+  val widthDp: Int? = null,
+  val heightDp: Int? = null,
+  val device: String? = null,
 )
 
 internal data class HPreviewParam(val name: String = "", val provider: String = "")
@@ -109,6 +112,9 @@ internal fun parseGraph(text: String): HGraph {
           thumbnail = po.str("thumbnail"),
           primary = po.bool("primary"),
           locale = po.str("locale"),
+          widthDp = po.int("widthDp"),
+          heightDp = po.int("heightDp"),
+          device = po.str("device"),
         )
       },
       start = o.bool("start"),

--- a/compose-nav-graph-ksp/src/main/kotlin/com/github/skydoves/navgraph/ksp/NavGraphProcessor.kt
+++ b/compose-nav-graph-ksp/src/main/kotlin/com/github/skydoves/navgraph/ksp/NavGraphProcessor.kt
@@ -128,6 +128,7 @@ internal class NavGraphProcessor(
       .forEach { fn ->
         fn.annotationsNamed(NAV_PREVIEW).forEach { ann ->
           val route = ann.typeArgFqn("route") ?: return@forEach
+          val size = previewSizeOf(fn)
           previews.getOrPut(route) { mutableListOf() }.add(
             NavPreviewRef(
               previewName = fn.simpleName.asString(),
@@ -136,6 +137,9 @@ internal class NavGraphProcessor(
               previewParameters = previewParametersOf(fn),
               primary = ann.boolArg("primary"),
               locale = previewLocaleOf(fn),
+              widthDp = size.widthDp,
+              heightDp = size.heightDp,
+              device = size.device,
             ),
           )
         }
@@ -319,6 +323,7 @@ internal class NavGraphProcessor(
             fn.simpleName.asString()
           }
           val n = seen.merge(base, 1, Int::plus)!!
+          val size = previewSizeOf(fn)
           NavPreviewRef(
             previewName = if (n == 1) base else "$base#$n",
             previewFqn = fn.qualifiedName?.asString(),
@@ -326,6 +331,9 @@ internal class NavGraphProcessor(
             previewParameters = previewParametersOf(fn),
             primary = false,
             locale = previewLocaleOf(fn),
+            widthDp = size.widthDp,
+            heightDp = size.heightDp,
+            device = size.device,
           )
         }
       // The slug is lossy (two packages/modules differing only by `_` vs `.`/`-`/`:` collapse to one), so append
@@ -402,6 +410,37 @@ internal class NavGraphProcessor(
     }
     return null
   }
+
+  /**
+   * The `@Preview(widthDp/heightDp/device)` sizing the function's preview declares (null per field when none).
+   * Walks annotations in declaration order — recursing into multipreview meta-annotations (same cycle guard as
+   * [previewLocaleOf]) — and returns the FIRST `@Preview` that declares any sizing, taking width/height/device
+   * from that one annotation so a landscape preview's width and height stay paired.
+   */
+  private fun previewSizeOf(fn: KSFunctionDeclaration): PreviewSize =
+    firstPreviewSize(fn.annotations, mutableSetOf()) ?: PreviewSize(null, null, null)
+
+  private fun firstPreviewSize(
+    annotations: Sequence<KSAnnotation>,
+    visited: MutableSet<String>,
+  ): PreviewSize? {
+    for (ann in annotations) {
+      val decl = ann.annotationType.resolve().declaration as? KSClassDeclaration ?: continue
+      val name = decl.qualifiedName?.asString() ?: continue
+      if (name == PREVIEW) {
+        val w = ann.intArg("widthDp")?.takeIf { it > 0 }
+        val h = ann.intArg("heightDp")?.takeIf { it > 0 }
+        val device = ann.stringArg("device")?.takeIf(String::isNotBlank)
+        if (w != null || h != null || device != null) return PreviewSize(w, h, device)
+        continue
+      }
+      if (!visited.add(name)) continue
+      firstPreviewSize(decl.annotations, visited)?.let { return it }
+    }
+    return null
+  }
+
+  private data class PreviewSize(val widthDp: Int?, val heightDp: Int?, val device: String?)
 
   /**
    * Serializable properties = the navigation arguments: primary-constructor properties (in ctor order) then
@@ -624,6 +663,8 @@ private fun KSAnnotation.typeArgFqn(name: String): String? {
 private fun KSAnnotation.stringArg(name: String): String? = arg(name) as? String
 
 private fun KSAnnotation.boolArg(name: String): Boolean = arg(name) as? Boolean ?: false
+
+private fun KSAnnotation.intArg(name: String): Int? = arg(name) as? Int
 
 private fun KSAnnotation.arg(name: String): Any? = arguments.firstOrNull {
   it.name?.asString() ==

--- a/compose-nav-graph-ksp/src/test/kotlin/com/github/skydoves/navgraph/ksp/NavGraphProcessorTest.kt
+++ b/compose-nav-graph-ksp/src/test/kotlin/com/github/skydoves/navgraph/ksp/NavGraphProcessorTest.kt
@@ -369,6 +369,56 @@ class NavGraphProcessorTest {
   }
 
   @Test
+  fun navPreview_carriesPreviewSizeAndDevice() {
+    val graph = compileNavGraph(
+      SourceFile.kotlin(
+        "Previews.kt",
+        """
+        package com.app
+        import androidx.compose.ui.tooling.preview.Preview
+        import androidx.navigation3.runtime.NavKey
+        import com.github.skydoves.navgraph.annotations.NavPreview
+        class Profile : NavKey
+        @Preview(widthDp = 1280, heightDp = 800, device = "spec:width=1280dp,height=800dp,dpi=240")
+        @NavPreview(route = Profile::class, primary = true)
+        fun ProfilePreview() {}
+        """.trimIndent(),
+      ),
+      PREVIEW_STUB,
+    )
+
+    val preview = graph.node("Profile").previews.single()
+    assertEquals(1280, preview.widthDp)
+    assertEquals(800, preview.heightDp)
+    assertEquals("spec:width=1280dp,height=800dp,dpi=240", preview.device)
+  }
+
+  @Test
+  fun navPreview_withoutSize_hasNullSize() {
+    val graph = compileNavGraph(
+      SourceFile.kotlin(
+        "Previews.kt",
+        """
+        package com.app
+        import androidx.compose.ui.tooling.preview.Preview
+        import androidx.navigation3.runtime.NavKey
+        import com.github.skydoves.navgraph.annotations.NavPreview
+        class Profile : NavKey
+        @Preview
+        @NavPreview(route = Profile::class, primary = true)
+        fun ProfilePreview() {}
+        """.trimIndent(),
+      ),
+      PREVIEW_STUB,
+    )
+
+    val preview = graph.node("Profile").previews.single()
+    assertEquals(null, preview.widthDp)
+    assertEquals(null, preview.heightDp)
+    assertEquals(null, preview.device)
+  }
+
+  @Test
   fun navPreview_multiplePreviewsSortPrimaryFirst() {
     val graph = compileNavGraph(
       SourceFile.kotlin(

--- a/compose-nav-graph-ksp/src/test/kotlin/com/github/skydoves/navgraph/ksp/NavGraphTestSupport.kt
+++ b/compose-nav-graph-ksp/src/test/kotlin/com/github/skydoves/navgraph/ksp/NavGraphTestSupport.kt
@@ -44,6 +44,9 @@ internal val PREVIEW_STUB = SourceFile.kotlin(
   annotation class Preview(
     val name: String = "",
     val locale: String = "",
+    val widthDp: Int = -1,
+    val heightDp: Int = -1,
+    val device: String = "",
   )
   """.trimIndent(),
 )


### PR DESCRIPTION
NavGraph thumbnails always rendered at a fixed phone-portrait canvas: KSP extracted only `locale` from `@Preview` and the Layoutlib renderer hardcoded a single device, so `widthDp`/`heightDp`/`device` never reached the render.

- Extract `widthDp`/`heightDp`/`device` in KSP (mirroring the `locale` walk, including multipreview meta-annotations) and carry them through the shared model + the Gradle manifest.
- In the Layoutlib render, pass an explicit `device` through and synthesize a `spec:` from `widthDp`/`heightDp`; keep the fixed phone default only when the preview declares no size, so unsized lazy layouts stay bounded.

Layoutlib backend only; the Robolectric backend keeps a fixed size for now (its device comes from a class-level `@Config` qualifier).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying custom screen dimensions (width/height in dp) and device types for navigation graph previews. The preview system now extracts and applies these custom configurations when rendering previews, with graceful fallback to default dimensions when not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->