### PR TITLE
Add package-level feature scoping for the navigation graph (#19)

### DIFF
--- a/compose-nav-graph-gradle/src/main/kotlin/com/github/skydoves/navgraph/gradle/ExportNavGraphHtmlTask.kt
+++ b/compose-nav-graph-gradle/src/main/kotlin/com/github/skydoves/navgraph/gradle/ExportNavGraphHtmlTask.kt
@@ -61,6 +61,12 @@ public abstract class ExportNavGraphHtmlTask : DefaultTask() {
   @get:Optional
   public abstract val deviceSpec: Property<String>
 
+  /** "" = the whole graph; else a package prefix (e.g. "com.app.feature.feed") to export only that feature's
+   *  subgraph (nodes whose route/screen FQN is under it, plus their internal edges). */
+  @get:Input
+  @get:Optional
+  public abstract val packageFilter: Property<String>
+
   @get:OutputFile
   public abstract val outputHtml: RegularFileProperty
 
@@ -73,7 +79,11 @@ public abstract class ExportNavGraphHtmlTask : DefaultTask() {
   @TaskAction
   public fun export() {
     val manifestFile = manifest.get().asFile
-    val graph = parseGraph(manifestFile.readText())
+    val pkg = packageFilter.orNull.orEmpty()
+    val graph = filterGraphByPackage(parseGraph(manifestFile.readText()), pkg)
+    if (pkg.isNotBlank() && graph.nodes.isEmpty()) {
+      logger.warn("navgraph: no destinations under package '$pkg'; exporting an empty graph.")
+    }
     val thumbsRoot: File? = thumbsDir.orNull?.asFile
     val device = parseDevice(deviceSpec.orNull)
     // "Generated" date = the graph data's timestamp (manifest mtime), not now() — keeps the output

--- a/compose-nav-graph-gradle/src/main/kotlin/com/github/skydoves/navgraph/gradle/ExportNavGraphImageTask.kt
+++ b/compose-nav-graph-gradle/src/main/kotlin/com/github/skydoves/navgraph/gradle/ExportNavGraphImageTask.kt
@@ -67,6 +67,12 @@ public abstract class ExportNavGraphImageTask : DefaultTask() {
   @get:Optional
   public abstract val deviceSpec: Property<String>
 
+  /** "" = the whole graph; else a package prefix (e.g. "com.app.feature.feed") to export only that feature's
+   *  subgraph (nodes whose route/screen FQN is under it, plus their internal edges). */
+  @get:Input
+  @get:Optional
+  public abstract val packageFilter: Property<String>
+
   /** Supersampling factor — the image is rendered at this multiple and `g2.scale(scale)`d for crisp hi-DPI. */
   @get:Input
   @get:Optional
@@ -78,7 +84,11 @@ public abstract class ExportNavGraphImageTask : DefaultTask() {
   @TaskAction
   public fun export() {
     val manifestFile = manifest.get().asFile
-    val graph = parseGraph(manifestFile.readText())
+    val pkg = packageFilter.orNull.orEmpty()
+    val graph = filterGraphByPackage(parseGraph(manifestFile.readText()), pkg)
+    if (pkg.isNotBlank() && graph.nodes.isEmpty()) {
+      logger.warn("navgraph: no destinations under package '$pkg'; exporting an empty graph.")
+    }
     val thumbsRoot: File? = thumbsDir.orNull?.asFile
     val device = parseDevice(deviceSpec.orNull)
     val s = (scale.orNull ?: DEFAULT_SCALE).coerceIn(1, 8)

--- a/compose-nav-graph-gradle/src/main/kotlin/com/github/skydoves/navgraph/gradle/NavGraphGradlePlugin.kt
+++ b/compose-nav-graph-gradle/src/main/kotlin/com/github/skydoves/navgraph/gradle/NavGraphGradlePlugin.kt
@@ -575,6 +575,7 @@ public class NavGraphGradlePlugin : Plugin<Project> {
         manifest.set(graphSourceDir.map { it.file("nav-graph.json") })
         this.thumbsDir.set(graphSourceDir.map { it.dir("thumbs") })
         deviceSpec.set(providers.gradleProperty("navgraph.export.device").orElse(""))
+        packageFilter.set(providers.gradleProperty("navgraph.export.package").orElse(""))
         outputHtml.set(
           layout.file(providers.gradleProperty("navgraph.export.out").map { File(it) })
             .orElse(navgraphDir.map { it.file("nav-graph.html") }),
@@ -589,6 +590,7 @@ public class NavGraphGradlePlugin : Plugin<Project> {
         manifest.set(graphSourceDir.map { it.file("nav-graph.json") })
         this.thumbsDir.set(graphSourceDir.map { it.dir("thumbs") })
         deviceSpec.set(providers.gradleProperty("navgraph.export.device").orElse(""))
+        packageFilter.set(providers.gradleProperty("navgraph.export.package").orElse(""))
         scale.set(providers.gradleProperty("navgraph.export.scale").map { it.toInt() })
         outputImage.set(
           layout.file(providers.gradleProperty("navgraph.export.out").map { File(it) })

--- a/compose-nav-graph-gradle/src/main/kotlin/com/github/skydoves/navgraph/gradle/NavManifest.kt
+++ b/compose-nav-graph-gradle/src/main/kotlin/com/github/skydoves/navgraph/gradle/NavManifest.kt
@@ -75,6 +75,19 @@ internal data class HPreviewParam(val name: String = "", val provider: String = 
 
 internal data class HEdge(val from: String = "", val to: String = "", val label: String? = null)
 
+/** Restrict [graph] to a feature package [prefix] (e.g. `com.app.feature.feed`): keep nodes whose route FQN
+ *  (`id`) or screen FQN (`clickTargetFqn`) is under that package, plus edges with both endpoints kept. A blank
+ *  prefix returns [graph] unchanged. Backs the `-Pnavgraph.export.package=` filter for single-module apps that
+ *  organize screens by feature package. */
+internal fun filterGraphByPackage(graph: HGraph, prefix: String): HGraph {
+  if (prefix.isBlank()) return graph
+  fun underPackage(fqn: String?): Boolean =
+    fqn != null && (fqn == prefix || fqn.startsWith("$prefix."))
+  val nodes = graph.nodes.filter { underPackage(it.id) || underPackage(it.clickTargetFqn) }
+  val ids = nodes.mapTo(HashSet()) { it.id }
+  return graph.copy(nodes = nodes, edges = graph.edges.filter { it.from in ids && it.to in ids })
+}
+
 internal fun parseGraph(text: String): HGraph {
   val root = Json.parseToJsonElement(text).jsonObject
   val nodes = root.arr("nodes").map { el ->

--- a/compose-nav-graph-gradle/src/test/kotlin/com/github/skydoves/navgraph/gradle/NavManifestParseTest.kt
+++ b/compose-nav-graph-gradle/src/test/kotlin/com/github/skydoves/navgraph/gradle/NavManifestParseTest.kt
@@ -24,6 +24,52 @@ import org.junit.Test
 class NavManifestParseTest {
 
   @Test
+  fun filterByPackage_keepsNodesUnderPrefixAndDropsCrossFeatureEdges() {
+    val graph = HGraph(
+      nodes = listOf(
+        HNode(id = "app.feed.FeedRoute", clickTargetFqn = "app.feed.FeedScreen"),
+        HNode(id = "app.feed.detail.DetailRoute"),
+        HNode(id = "app.profile.ProfileRoute"),
+      ),
+      edges = listOf(
+        HEdge(from = "app.feed.FeedRoute", to = "app.feed.detail.DetailRoute"),
+        HEdge(from = "app.feed.FeedRoute", to = "app.profile.ProfileRoute"),
+      ),
+    )
+
+    val feed = filterGraphByPackage(graph, "app.feed")
+
+    assertEquals(
+      listOf("app.feed.FeedRoute", "app.feed.detail.DetailRoute"),
+      feed.nodes.map {
+        it.id
+      },
+    )
+    assertEquals(1, feed.edges.size)
+    assertEquals("app.feed.detail.DetailRoute", feed.edges.single().to)
+  }
+
+  @Test
+  fun filterByPackage_matchesViaScreenFqnAndIgnoresPartialSegments() {
+    val graph = HGraph(
+      nodes = listOf(
+        HNode(id = "app.routes.SearchRoute", clickTargetFqn = "app.feed.SearchScreen"),
+        HNode(id = "app.feedback.FeedbackRoute"),
+      ),
+    )
+
+    // Kept via clickTargetFqn; `feedback` is NOT under `feed` (segment boundary).
+    val kept = filterGraphByPackage(graph, "app.feed").nodes.map { it.id }
+    assertEquals(listOf("app.routes.SearchRoute"), kept)
+  }
+
+  @Test
+  fun filterByPackage_blankPrefixReturnsUnchanged() {
+    val graph = HGraph(nodes = listOf(HNode(id = "app.A")))
+    assertEquals(graph, filterGraphByPackage(graph, ""))
+  }
+
+  @Test
   fun parsesNodesEdgesArgsAndStart() {
     val json = """
       {

--- a/compose-nav-graph-idea/src/main/kotlin/com/github/skydoves/navgraph/idea/NavFeatureGrouping.kt
+++ b/compose-nav-graph-idea/src/main/kotlin/com/github/skydoves/navgraph/idea/NavFeatureGrouping.kt
@@ -1,0 +1,96 @@
+/*
+ * Designed and developed by 2026 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.skydoves.navgraph.idea
+
+import com.github.skydoves.navgraph.idea.model.NavGraphDto
+import com.github.skydoves.navgraph.idea.model.NavNodeDto
+
+/**
+ * Splits one graph into **feature groups by package** — the within-module counterpart of [NavScopeGrouping]
+ * (which groups by Gradle module). For apps that keep every screen in a single `:app` module and organize them
+ * by feature package (`feature.feed`, `feature.profile`, …), this powers the tool window's "Feature:" selector
+ * so the user can view/export one feature's subgraph at a time. No IntelliJ types, so it is unit-testable, and
+ * the filter mirrors the Gradle `filterGraphByPackage` exactly so the on-screen view and an export agree.
+ *
+ * **Auto-discovery (no configuration).** Anchor at the longest package prefix every destination shares (the
+ * common root, e.g. `com.app.feature`), then bucket by the single segment that follows it (`feed`, `profile`).
+ * Screens deeper in a feature (`com.app.feature.feed.detail.DetailScreen`) fold into that feature. When fewer
+ * than two buckets emerge there is nothing to choose between, so [computeFeatures] returns empty and the caller
+ * hides the selector. A destination sitting directly under the common root (no further segment) has no feature
+ * of its own — it only appears under "All features".
+ */
+internal object NavFeatureGrouping {
+
+  /** @property name the segment shown in the selector; @property packagePrefix what [filterByPackage] keys on. */
+  data class Feature(val name: String, val packagePrefix: String)
+
+  /**
+   * The feature groups discovered in [graph], sorted by name. Empty when fewer than two distinct features
+   * exist (single-feature or flat apps) — the selector is then pointless and stays hidden.
+   */
+  fun computeFeatures(graph: NavGraphDto): List<Feature> {
+    val packages = graph.nodes.mapNotNull {
+      it.featureFqn()?.let(::packageOf)
+    }.filter { it.isNotBlank() }
+    if (packages.size < 2) return emptyList()
+
+    val common = commonPackagePrefix(packages)
+    val rootDepth = if (common.isEmpty()) 0 else common.split('.').size
+    // The segment right after the shared root is the feature; a package with nothing past the root contributes
+    // no feature key (those destinations live only under "All features").
+    val keys = LinkedHashSet<String>()
+    for (pkg in packages) {
+      val segments = pkg.split('.')
+      if (segments.size > rootDepth) keys.add(segments[rootDepth])
+    }
+    if (keys.size < 2) return emptyList()
+
+    return keys.sorted().map { key ->
+      Feature(name = key, packagePrefix = if (common.isEmpty()) key else "$common.$key")
+    }
+  }
+
+  /**
+   * Restrict [graph] to the destinations under [prefix] — a node is kept when its route FQN ([NavNodeDto.id])
+   * OR its screen FQN ([NavNodeDto.clickTargetFqn]) is the prefix or nested under it, and an edge survives only
+   * when both endpoints do. A blank [prefix] returns [graph] unchanged. Byte-for-byte the Gradle export filter.
+   */
+  fun filterByPackage(graph: NavGraphDto, prefix: String): NavGraphDto {
+    if (prefix.isBlank()) return graph
+    fun underPackage(fqn: String?): Boolean =
+      fqn != null && (fqn == prefix || fqn.startsWith("$prefix."))
+    val nodes = graph.nodes.filter { underPackage(it.id) || underPackage(it.clickTargetFqn) }
+    val ids = nodes.mapTo(HashSet()) { it.id }
+    return graph.copy(nodes = nodes, edges = graph.edges.filter { it.from in ids && it.to in ids })
+  }
+
+  /** The screen FQN drives the feature (it is where the code lives); the route id is the fallback when the
+   *  screen FQN is absent OR blank (a hand-authored manifest may carry an empty `clickTargetFqn`). */
+  private fun NavNodeDto.featureFqn(): String? =
+    (clickTargetFqn?.ifBlank { null } ?: id).ifBlank { null }
+
+  /** Package of a fully-qualified name: everything before the final segment (the simple type name). */
+  private fun packageOf(fqn: String): String = fqn.substringBeforeLast('.', "")
+
+  /** The longest run of leading package segments shared by every entry (segment-wise, never mid-segment). */
+  private fun commonPackagePrefix(packages: List<String>): String {
+    val split = packages.map { it.split('.') }
+    val first = split.first()
+    var depth = 0
+    while (depth < first.size && split.all { it.size > depth && it[depth] == first[depth] }) depth++
+    return first.take(depth).joinToString(".")
+  }
+}

--- a/compose-nav-graph-idea/src/main/kotlin/com/github/skydoves/navgraph/idea/NavGraphPanel.kt
+++ b/compose-nav-graph-idea/src/main/kotlin/com/github/skydoves/navgraph/idea/NavGraphPanel.kt
@@ -57,6 +57,7 @@ import java.awt.BorderLayout
 import java.awt.Component
 import java.awt.FlowLayout
 import java.awt.Font
+import java.awt.image.BufferedImage
 import java.io.File
 import java.nio.file.Path
 import javax.swing.DefaultListCellRenderer
@@ -98,10 +99,22 @@ internal class NavGraphPanel(private val project: Project, parentDisposable: Dis
   private var currentGraph: NavGraphDto? = null
 
   /**
+   * The selected scope's full graph + thumbs, before any "Feature:" filter. The feature selector narrows this
+   * into [currentGraph]; keeping the base lets the user switch features (and back to "All") without a reload.
+   */
+  private var baseGraph: NavGraphDto? = null
+  private var baseThumbs: Map<String, BufferedImage> = emptyMap()
+
+  /**
    * Guards [scopeCombo]'s listener while its items are rebuilt in [applyScopes] (else the
    * rebuild fires it).
    */
   private var suppressScopeEvents = false
+
+  /**
+   * Guards [featureCombo]'s listener while its items are rebuilt for a new scope (else the rebuild fires it).
+   */
+  private var suppressFeatureEvents = false
 
   /**
    * "Project:" selector — picks which independent app's graph to render. Hidden for single-app
@@ -115,8 +128,7 @@ internal class NavGraphPanel(private val project: Project, parentDisposable: Dis
       if (suppressScopeEvents) return@addActionListener
       (selectedItem as? NavGraphReader.LoadedScope)?.let { scope ->
         NavGraphSettings.getInstance(project).selectedScopeId = scope.id
-        currentGraph = scope.graph
-        canvas.setGraph(scope.graph, scope.thumbs)
+        setScope(scope)
       }
     }
   }
@@ -125,6 +137,28 @@ internal class NavGraphPanel(private val project: Project, parentDisposable: Dis
     isVisible = false
     add(JLabel("Project:"))
     add(scopeCombo)
+  }
+
+  /**
+   * "Feature:" selector — narrows a single-module graph to one feature package's subgraph (see
+   * [NavFeatureGrouping]). Hidden unless the graph splits into 2+ features; index 0 is "All features".
+   */
+  private val featureCombo = ComboBox<NavFeatureGrouping.Feature>().apply {
+    toolTipText = "Show only one feature's destinations (grouped by package within this module)"
+    renderer = SimpleListCellRenderer.create<NavFeatureGrouping.Feature>("") { it?.name ?: "" }
+    addActionListener {
+      if (suppressFeatureEvents) return@addActionListener
+      (selectedItem as? NavFeatureGrouping.Feature)?.let { feature ->
+        NavGraphSettings.getInstance(project).selectedFeaturePrefix = feature.packagePrefix
+        applyFeatureFilter(refit = true)
+      }
+    }
+  }
+  private val featurePanel = JPanel(FlowLayout(FlowLayout.LEFT, 6, 2)).apply {
+    isOpaque = false
+    isVisible = false
+    add(JLabel("Feature:"))
+    add(featureCombo)
   }
 
   init {
@@ -150,11 +184,16 @@ internal class NavGraphPanel(private val project: Project, parentDisposable: Dis
       add(JLabel("Device:"))
       add(deviceCombo)
     }
+    val selectors = JPanel(FlowLayout(FlowLayout.LEFT, 0, 0)).apply {
+      isOpaque = false
+      add(scopePanel)
+      add(featurePanel)
+    }
     val leftPanel = JPanel(BorderLayout()).apply {
       isOpaque = false
       add(actionToolbar.component, BorderLayout.WEST)
-      // the app selector sits right of the actions; shown only when >1 app
-      add(scopePanel, BorderLayout.CENTER)
+      // the app + feature selectors sit right of the actions; each shows only when it has a real choice
+      add(selectors, BorderLayout.CENTER)
     }
     val header = JPanel(BorderLayout()).apply {
       add(leftPanel, BorderLayout.WEST)
@@ -191,7 +230,9 @@ internal class NavGraphPanel(private val project: Project, parentDisposable: Dis
     if (loaded.isEmpty()) {
       // drop any stale items so a later load is clean
       withSuppressedScopeEvents { scopeCombo.removeAllItems() }
+      withSuppressedFeatureEvents { featureCombo.removeAllItems() }
       scopePanel.isVisible = false
+      featurePanel.isVisible = false
       cardLayout.show(cards, CARD_EMPTY)
       return
     }
@@ -205,11 +246,51 @@ internal class NavGraphPanel(private val project: Project, parentDisposable: Dis
       loaded.forEach { scopeCombo.addItem(it) }
       scopeCombo.selectedItem = selected
     }
-
     scopePanel.isVisible = loaded.size > 1
-    currentGraph = selected.graph
+
     cardLayout.show(cards, CARD_GRAPH)
-    canvas.setGraph(selected.graph, selected.thumbs)
+    setScope(selected)
+  }
+
+  /**
+   * Make [scope] the active graph: remember it as the unfiltered [baseGraph], rebuild the feature selector from
+   * its packages, restore the remembered feature (or "All features"), then render. Runs on first load and on
+   * every scope switch.
+   */
+  private fun setScope(scope: NavGraphReader.LoadedScope) {
+    baseGraph = scope.graph
+    baseThumbs = scope.thumbs
+
+    val features = NavFeatureGrouping.computeFeatures(scope.graph)
+    val rememberedPrefix = NavGraphSettings.getInstance(project).selectedFeaturePrefix
+    val selectedFeature =
+      features.firstOrNull { it.packagePrefix == rememberedPrefix } ?: ALL_FEATURES
+    withSuppressedFeatureEvents {
+      featureCombo.removeAllItems()
+      if (features.isNotEmpty()) {
+        featureCombo.addItem(ALL_FEATURES)
+        features.forEach { featureCombo.addItem(it) }
+        featureCombo.selectedItem = selectedFeature
+      }
+    }
+    // A single (or no) feature offers no choice — keep the selector hidden, like the app selector for one app.
+    featurePanel.isVisible = features.isNotEmpty()
+
+    applyFeatureFilter(refit = false)
+  }
+
+  /**
+   * Re-render [baseGraph] narrowed to the selected feature (whole graph for "All features"). [refit] reframes
+   * the canvas to the new subgraph — wanted on a user feature switch, but not on the initial per-scope render,
+   * which already honors the auto-fit setting.
+   */
+  private fun applyFeatureFilter(refit: Boolean) {
+    val base = baseGraph ?: return
+    val prefix = (featureCombo.selectedItem as? NavFeatureGrouping.Feature)?.packagePrefix.orEmpty()
+    val filtered = NavFeatureGrouping.filterByPackage(base, prefix)
+    currentGraph = filtered
+    canvas.setGraph(filtered, baseThumbs)
+    if (refit) canvas.fit()
   }
 
   /**
@@ -222,6 +303,18 @@ internal class NavGraphPanel(private val project: Project, parentDisposable: Dis
       block()
     } finally {
       suppressScopeEvents = false
+    }
+  }
+
+  /**
+   * Runs [block] with the feature-combo listener muted, always restoring the flag (even if Swing throws).
+   */
+  private inline fun withSuppressedFeatureEvents(block: () -> Unit) {
+    suppressFeatureEvents = true
+    try {
+      block()
+    } finally {
+      suppressFeatureEvents = false
     }
   }
 
@@ -440,10 +533,17 @@ internal class NavGraphPanel(private val project: Project, parentDisposable: Dis
     // Quote the path: ExternalSystem splits scriptParameters on unquoted whitespace, so a
     // destination with a space (e.g. "~/My Drive/…") would otherwise be truncated into stray
     // task names.
+    // When a feature is selected, export exactly that subgraph — the same `-Pnavgraph.export.package` filter the
+    // Gradle tasks honor — so the file matches what the tool window is showing. A package prefix has no spaces.
+    val featurePrefix =
+      (featureCombo.selectedItem as? NavFeatureGrouping.Feature)?.packagePrefix.orEmpty()
     val params = buildString {
       append("-Pnavgraph.export.out=\"").append(target.absolutePath).append('"')
       if (!device.isAuto) {
         append(" -Pnavgraph.export.device=").append(device.w).append('x').append(device.h)
+      }
+      if (featurePrefix.isNotBlank()) {
+        append(" -Pnavgraph.export.package=").append(featurePrefix)
       }
     }
 
@@ -525,6 +625,9 @@ internal class NavGraphPanel(private val project: Project, parentDisposable: Dis
     /** [JBCardLayout] keys: the Java2D graph/canvas vs. the Swing setup-guide empty state. */
     const val CARD_GRAPH = "graph"
     const val CARD_EMPTY = "empty"
+
+    /** The "no filter" entry shown first in the feature selector; its blank prefix means the whole scope. */
+    val ALL_FEATURES = NavFeatureGrouping.Feature("All features", "")
   }
 }
 

--- a/compose-nav-graph-idea/src/main/kotlin/com/github/skydoves/navgraph/idea/settings/NavGraphSettings.kt
+++ b/compose-nav-graph-idea/src/main/kotlin/com/github/skydoves/navgraph/idea/settings/NavGraphSettings.kt
@@ -125,6 +125,13 @@ internal class NavGraphSettings : PersistentStateComponent<NavGraphSettings> {
    */
   var selectedScopeId: String = ""
 
+  /**
+   * Package prefix of the last-selected feature filter for a single-module app organized by feature packages
+   * (e.g. `com.app.feature.feed`). `""` = "All features" (no filter). A prefix that no longer matches any
+   * destination in the current scope falls back silently to "All".
+   */
+  var selectedFeaturePrefix: String = ""
+
   override fun getState(): NavGraphSettings = this
 
   override fun loadState(state: NavGraphSettings) {

--- a/compose-nav-graph-idea/src/test/kotlin/com/github/skydoves/navgraph/idea/NavFeatureGroupingTest.kt
+++ b/compose-nav-graph-idea/src/test/kotlin/com/github/skydoves/navgraph/idea/NavFeatureGroupingTest.kt
@@ -1,0 +1,174 @@
+/*
+ * Designed and developed by 2026 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.skydoves.navgraph.idea
+
+import com.github.skydoves.navgraph.idea.model.NavEdgeDto
+import com.github.skydoves.navgraph.idea.model.NavGraphDto
+import com.github.skydoves.navgraph.idea.model.NavNodeDto
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-logic tests for [NavFeatureGrouping] — the within-module "view one feature at a time" feature (#19). The
+ * shape under test is the reporter's: every screen in one `:app` module, organized by `feature.<name>` packages.
+ */
+class NavFeatureGroupingTest {
+
+  private fun nodes(vararg fqns: String): NavGraphDto =
+    NavGraphDto(nodes = fqns.map { NavNodeDto(id = it, clickTargetFqn = it) })
+
+  private fun featuresOf(graph: NavGraphDto) =
+    NavFeatureGrouping.computeFeatures(graph).map { it.name to it.packagePrefix }
+
+  @Test
+  fun discoversFeaturesByPackageAfterCommonRoot() {
+    val graph = nodes(
+      "com.app.feature.feed.FeedScreen",
+      "com.app.feature.profile.ProfileScreen",
+      "com.app.feature.settings.SettingsScreen",
+    )
+    assertEquals(
+      listOf(
+        "feed" to "com.app.feature.feed",
+        "profile" to "com.app.feature.profile",
+        "settings" to "com.app.feature.settings",
+      ),
+      featuresOf(graph),
+    )
+  }
+
+  @Test
+  fun nestedSubpackageFoldsIntoItsFeature() {
+    val graph = nodes(
+      "com.app.feed.FeedScreen",
+      "com.app.feed.detail.DetailScreen",
+      "com.app.profile.ProfileScreen",
+    )
+    // `feed.detail` is part of `feed`, not its own feature.
+    assertEquals(
+      listOf("feed" to "com.app.feed", "profile" to "com.app.profile"),
+      featuresOf(graph),
+    )
+  }
+
+  @Test
+  fun featureKeysRespectSegmentBoundaries() {
+    val graph = nodes("com.app.feed.FeedScreen", "com.app.feedback.FeedbackScreen")
+    // `feed` and `feedback` are siblings, not one nested in the other.
+    assertEquals(
+      listOf("feed" to "com.app.feed", "feedback" to "com.app.feedback"),
+      featuresOf(graph),
+    )
+  }
+
+  @Test
+  fun derivesFeatureFromScreenFqnNotRouteId() {
+    val graph = NavGraphDto(
+      nodes = listOf(
+        NavNodeDto(id = "com.app.routes.FeedRoute", clickTargetFqn = "com.app.feed.FeedScreen"),
+        NavNodeDto(
+          id = "com.app.routes.ProfileRoute",
+          clickTargetFqn = "com.app.profile.ProfileScreen",
+        ),
+      ),
+    )
+    assertEquals(
+      listOf("feed" to "com.app.feed", "profile" to "com.app.profile"),
+      featuresOf(graph),
+    )
+  }
+
+  @Test
+  fun fallsBackToRouteIdWhenScreenFqnNullOrBlank() {
+    // clickTargetFqn null (no screen) and explicitly blank both fall back to the route id.
+    val graph = NavGraphDto(
+      nodes = listOf(
+        NavNodeDto(id = "com.app.feed.FeedRoute", clickTargetFqn = null),
+        NavNodeDto(id = "com.app.profile.ProfileRoute", clickTargetFqn = ""),
+      ),
+    )
+    assertEquals(
+      listOf("feed" to "com.app.feed", "profile" to "com.app.profile"),
+      featuresOf(graph),
+    )
+  }
+
+  @Test
+  fun disjointTopLevelPackagesGroupByFirstSegment() {
+    // No shared root at all — the first package segment is the only sensible feature key.
+    val graph = nodes("com.app.FeedScreen", "org.lib.ProfileScreen")
+    assertEquals(listOf("com" to "com", "org" to "org"), featuresOf(graph))
+  }
+
+  @Test
+  fun singleFeatureProducesNoSelector() {
+    val graph = nodes("com.app.feed.FeedScreen", "com.app.feed.detail.DetailScreen")
+    assertTrue(NavFeatureGrouping.computeFeatures(graph).isEmpty())
+  }
+
+  @Test
+  fun filterKeepsFeatureNodesAndDropsCrossFeatureEdges() {
+    val graph = NavGraphDto(
+      nodes = listOf(
+        NavNodeDto(id = "com.app.feed.FeedScreen", clickTargetFqn = "com.app.feed.FeedScreen"),
+        NavNodeDto(
+          id = "com.app.feed.detail.DetailScreen",
+          clickTargetFqn = "com.app.feed.detail.DetailScreen",
+        ),
+        NavNodeDto(
+          id = "com.app.profile.ProfileScreen",
+          clickTargetFqn = "com.app.profile.ProfileScreen",
+        ),
+      ),
+      edges = listOf(
+        NavEdgeDto(from = "com.app.feed.FeedScreen", to = "com.app.feed.detail.DetailScreen"),
+        NavEdgeDto(from = "com.app.feed.FeedScreen", to = "com.app.profile.ProfileScreen"),
+      ),
+    )
+    val feed = NavFeatureGrouping.filterByPackage(graph, "com.app.feed")
+    assertEquals(
+      listOf("com.app.feed.FeedScreen", "com.app.feed.detail.DetailScreen"),
+      feed.nodes.map { it.id },
+    )
+    assertEquals(1, feed.edges.size)
+    assertEquals("com.app.feed.detail.DetailScreen", feed.edges.single().to)
+  }
+
+  @Test
+  fun filterMatchesViaScreenFqnAndIgnoresPartialSegments() {
+    val graph = NavGraphDto(
+      nodes = listOf(
+        NavNodeDto(id = "com.app.routes.SearchRoute", clickTargetFqn = "com.app.feed.SearchScreen"),
+        NavNodeDto(
+          id = "com.app.feedback.FeedbackScreen",
+          clickTargetFqn = "com.app.feedback.FeedbackScreen",
+        ),
+      ),
+    )
+    // Kept via clickTargetFqn; `feedback` is NOT under `feed`.
+    assertEquals(
+      listOf("com.app.routes.SearchRoute"),
+      NavFeatureGrouping.filterByPackage(graph, "com.app.feed").nodes.map { it.id },
+    )
+  }
+
+  @Test
+  fun filterWithBlankPrefixReturnsGraphUnchanged() {
+    val graph = nodes("com.app.A", "com.app.B")
+    assertEquals(graph, NavFeatureGrouping.filterByPackage(graph, ""))
+  }
+}

--- a/docs/gradle-plugin/export.md
+++ b/docs/gradle-plugin/export.md
@@ -65,6 +65,7 @@ The export tasks accept a few `-P` Gradle properties to tweak the output without
 |----------|------------|--------|
 | `navgraph.export.device` | `exportNavGraphHtml`, `exportNavGraphImage` | Frames every thumbnail in a `WxH` device frame (letterboxed), e.g. `1080x2400`. Blank (the default) keeps each node at its rendered aspect. |
 | `navgraph.export.out` | `exportNavGraphHtml`, `exportNavGraphImage` | Redirects the output file to the given path. |
+| `navgraph.export.package` | `exportNavGraphHtml`, `exportNavGraphImage` | Exports only the destinations under a package prefix (e.g. `com.app.feature.feed`), nested screens included, plus their internal edges. For single module apps organized by feature package. Blank (the default) exports the whole graph. |
 | `navgraph.export.scale` | `exportNavGraphImage`, `exportPreviewGalleryImage` | Supersampling factor for crisp hi-DPI PNGs (default `2`, clamped to `1`..`8`). |
 | `navgraph.gallery.out` | `exportPreviewGalleryHtml`, `exportPreviewGalleryImage` | Redirects the gallery output file to the given path. |
 
@@ -76,6 +77,18 @@ For example, to export a hi-DPI PNG with phone framed thumbnails to a custom loc
     -Pnavgraph.export.scale=3 \
     -Pnavgraph.export.out=docs/nav-graph.png
 ```
+
+## Scope the export to one feature
+
+If your app keeps every screen in a single module and organizes them by feature package, you can export one feature's subgraph at a time with `navgraph.export.package`. It keeps the destinations whose route or screen lives under the given package (nested screens included) and drops any edge that crosses out of it:
+
+```bash
+./gradlew :app:exportNavGraphImage \
+    -Pnavgraph.export.package=com.app.feature.feed \
+    -Pnavgraph.export.out=docs/feed-graph.png
+```
+
+The IDE tool window exposes the same filter as a "Feature:" selector, so exporting from there passes this property for the feature you are currently viewing.
 
 ## Embedding in Docs
 

--- a/docs/ide-plugin/graph.md
+++ b/docs/ide-plugin/graph.md
@@ -10,6 +10,10 @@ The tool window shows the **whole app**, not one module at a time. The graph is 
 
 If your repository holds more than one independent app (several `:app`-like roots), each is loaded as its own selectable scope. The tool window remembers your last selected scope per project, and falls back to the first one if a module was removed or renamed.
 
+## Scope by Feature
+
+If your app keeps every screen in a single module and organizes them by feature package (for example `feature.feed`, `feature.profile`), a **Feature:** selector appears in the toolbar. It narrows the canvas to one feature's destinations at a time, so a large single-module graph stays readable. Features are discovered automatically from your package layout (the segment that follows the package all your screens share), and nested screens fold into their feature. The selector stays hidden when the graph has nothing to split. Picking a feature also scopes the [Export](#export) to that subgraph, matching what you see on screen.
+
 ## Thumbnails and Arguments
 
 Every node that has a `@NavPreview` shows that preview's **rendered thumbnail**: the same Layoutlib render produced at build time, no device needed. Nodes also list the route class's serializable properties as **typed argument rows**, so you can see at a glance what data each destination expects. Both regions can be toggled off in settings if you want a denser, structure only layout.

--- a/samples/sample/src/main/kotlin/com/github/skydoves/navgraph/sample/cart/CartFeature.kt
+++ b/samples/sample/src/main/kotlin/com/github/skydoves/navgraph/sample/cart/CartFeature.kt
@@ -1,0 +1,194 @@
+/*
+ * Designed and developed by 2026 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.skydoves.navgraph.sample.cart
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation3.runtime.NavKey
+import com.github.skydoves.navgraph.annotations.NavDestination
+import com.github.skydoves.navgraph.annotations.NavEdge
+import com.github.skydoves.navgraph.annotations.NavPreview
+import com.github.skydoves.navgraph.sample.NavSampleTheme
+import com.github.skydoves.navgraph.sample.orders.Orders
+import kotlinx.serialization.Serializable
+
+/**
+ * The **cart** feature (package `...sample.cart`). `Cart -> Checkout` is an internal edge; `Checkout -> Orders`
+ * crosses into the `orders` feature and is dropped when you scope the graph to `cart`. See [CatalogScreen]'s
+ * sibling package for the full "Feature:" selector story (#19).
+ */
+@Serializable
+sealed interface CartKey : NavKey
+
+@Serializable
+data object Cart : CartKey
+
+@Serializable
+data object Checkout : CartKey
+
+@NavEdge(to = Checkout::class, label = "checkout")
+@NavDestination(route = Cart::class)
+@Composable
+fun CartScreen(onCheckout: () -> Unit = {}) {
+  val lines = listOf(
+    "Aurora Headphones" to "$129",
+    "Nimbus Keyboard" to "$89",
+  )
+  CartScaffold(title = "Cart") {
+    Card(
+      modifier = Modifier.fillMaxWidth(),
+      shape = RoundedCornerShape(16.dp),
+      colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+    ) {
+      Column(
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+      ) {
+        lines.forEach { (name, price) -> CartLine(name = name, price = price) }
+        HorizontalDivider()
+        CartLine(name = "Total", price = "$218", emphasize = true)
+      }
+    }
+    Button(
+      onClick = onCheckout,
+      modifier = Modifier.fillMaxWidth(),
+      shape = RoundedCornerShape(16.dp),
+    ) {
+      Text(text = "Checkout", fontWeight = FontWeight.SemiBold)
+    }
+  }
+}
+
+@NavEdge(to = Orders::class, label = "place order")
+@NavDestination(route = Checkout::class)
+@Composable
+fun CheckoutScreen(onPlaceOrder: () -> Unit = {}) {
+  CartScaffold(title = "Checkout") {
+    Card(
+      modifier = Modifier.fillMaxWidth(),
+      shape = RoundedCornerShape(16.dp),
+      colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+    ) {
+      Column(
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+      ) {
+        Text(
+          text = "Shipping",
+          style = MaterialTheme.typography.titleMedium,
+          fontWeight = FontWeight.SemiBold,
+          color = MaterialTheme.colorScheme.onSurface,
+        )
+        Text(
+          text = "skydoves\n123 Compose Street\nSeoul",
+          style = MaterialTheme.typography.bodyMedium,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        HorizontalDivider()
+        CartLine(name = "Total due", price = "$218", emphasize = true)
+      }
+    }
+    Button(
+      onClick = onPlaceOrder,
+      modifier = Modifier.fillMaxWidth(),
+      shape = RoundedCornerShape(16.dp),
+    ) {
+      Text(text = "Place order", fontWeight = FontWeight.SemiBold)
+    }
+  }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CartScaffold(title: String, content: @Composable () -> Unit) {
+  Scaffold(
+    topBar = {
+      TopAppBar(title = { Text(text = title, fontWeight = FontWeight.Bold) })
+    },
+    containerColor = MaterialTheme.colorScheme.surfaceVariant,
+  ) { innerPadding ->
+    Column(
+      modifier = Modifier
+        .fillMaxSize()
+        .padding(innerPadding)
+        .padding(16.dp),
+      verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+      content()
+    }
+  }
+}
+
+@Composable
+private fun CartLine(name: String, price: String, emphasize: Boolean = false) {
+  val weight = if (emphasize) FontWeight.Bold else FontWeight.Normal
+  val priceColor =
+    if (emphasize) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface
+  Row(
+    modifier = Modifier.fillMaxWidth(),
+    horizontalArrangement = Arrangement.SpaceBetween,
+  ) {
+    Text(
+      text = name,
+      style = MaterialTheme.typography.bodyLarge,
+      fontWeight = weight,
+      color = MaterialTheme.colorScheme.onSurface,
+    )
+    Text(
+      text = price,
+      style = MaterialTheme.typography.bodyLarge,
+      fontWeight = weight,
+      color = priceColor,
+    )
+  }
+}
+
+@NavPreview(route = Cart::class, primary = true)
+@Preview(showBackground = true)
+@Composable
+internal fun CartScreenPreview() {
+  NavSampleTheme { CartScreen() }
+}
+
+@NavPreview(route = Checkout::class, primary = true)
+@Preview(showBackground = true)
+@Composable
+internal fun CheckoutScreenPreview() {
+  NavSampleTheme { CheckoutScreen() }
+}

--- a/samples/sample/src/main/kotlin/com/github/skydoves/navgraph/sample/catalog/CatalogFeature.kt
+++ b/samples/sample/src/main/kotlin/com/github/skydoves/navgraph/sample/catalog/CatalogFeature.kt
@@ -1,0 +1,223 @@
+/*
+ * Designed and developed by 2026 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.skydoves.navgraph.sample.catalog
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation3.runtime.NavKey
+import com.github.skydoves.navgraph.annotations.NavDestination
+import com.github.skydoves.navgraph.annotations.NavEdge
+import com.github.skydoves.navgraph.annotations.NavPreview
+import com.github.skydoves.navgraph.sample.NavSampleTheme
+import com.github.skydoves.navgraph.sample.cart.Cart
+import kotlinx.serialization.Serializable
+
+/**
+ * The **catalog** feature, kept in its own package `...sample.catalog`. Together with the sibling `cart` and
+ * `orders` packages it demonstrates the tool window's package-based "Feature:" selector (#19): a single-module
+ * graph organized by feature package can be viewed/exported one feature at a time. `Catalog -> Product` is an
+ * internal edge (kept under the `catalog` filter); `Catalog -> Cart` crosses into the `cart` feature and is
+ * dropped when you scope to `catalog`.
+ */
+@Serializable
+sealed interface CatalogKey : NavKey
+
+@Serializable
+data object Catalog : CatalogKey
+
+@Serializable
+data class Product(val productId: String) : CatalogKey
+
+@NavEdge(to = Product::class, label = "open")
+@NavEdge(to = Cart::class, label = "cart")
+@NavDestination(route = Catalog::class)
+@Composable
+fun CatalogScreen(onOpenProduct: (String) -> Unit = {}, onOpenCart: () -> Unit = {}) {
+  val items = listOf(
+    Triple("Aurora Headphones", "$129", Color(0xFF6D5BFF) to Color(0xFF22D3EE)),
+    Triple("Nimbus Keyboard", "$89", Color(0xFFFF6B6B) to Color(0xFFFF9F45)),
+    Triple("Lumen Desk Lamp", "$54", Color(0xFF12B886) to Color(0xFF0EA5E9)),
+  )
+  CatalogScaffold(title = "Catalog") {
+    items.forEachIndexed { index, (name, price, gradient) ->
+      ProductRowCard(
+        name = name,
+        price = price,
+        start = gradient.first,
+        end = gradient.second,
+        onClick = { onOpenProduct(name) }.takeIf { index == 0 },
+      )
+    }
+  }
+}
+
+@NavEdge(to = Cart::class, label = "add")
+@NavDestination(route = Product::class)
+@Composable
+fun ProductScreen(onAddToCart: () -> Unit = {}) {
+  CatalogScaffold(title = "Product") {
+    Card(
+      modifier = Modifier.fillMaxWidth(),
+      shape = RoundedCornerShape(16.dp),
+      elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+    ) {
+      Column {
+        Box(
+          modifier = Modifier
+            .fillMaxWidth()
+            .height(160.dp)
+            .background(Brush.linearGradient(listOf(Color(0xFF6D5BFF), Color(0xFF22D3EE)))),
+        )
+        Column(
+          modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+          verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+          Text(
+            text = "Aurora Headphones",
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
+          )
+          Text(
+            text = "$129",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.primary,
+          )
+          Text(
+            text = "Wireless over-ear headphones with adaptive noise cancellation and 30h battery.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+          )
+        }
+      }
+    }
+  }
+}
+
+/** Shared chrome for the catalog screens: a top bar over a padded, scroll-free column of content. */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CatalogScaffold(title: String, content: @Composable () -> Unit) {
+  Scaffold(
+    topBar = {
+      TopAppBar(
+        title = {
+          Text(text = title, fontWeight = FontWeight.Bold)
+        },
+      )
+    },
+    containerColor = MaterialTheme.colorScheme.surfaceVariant,
+  ) { innerPadding ->
+    Column(
+      modifier = Modifier
+        .fillMaxSize()
+        .padding(innerPadding)
+        .padding(16.dp),
+      verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+      content()
+    }
+  }
+}
+
+@Composable
+private fun ProductRowCard(
+  name: String,
+  price: String,
+  start: Color,
+  end: Color,
+  onClick: (() -> Unit)?,
+) {
+  val body: @Composable () -> Unit = {
+    Row(
+      modifier = Modifier
+        .fillMaxWidth()
+        .padding(12.dp),
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+      Box(
+        modifier = Modifier
+          .size(48.dp)
+          .clip(RoundedCornerShape(12.dp))
+          .background(Brush.linearGradient(listOf(start, end))),
+      )
+      Text(
+        text = name,
+        modifier = Modifier.weight(1f),
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.SemiBold,
+        color = MaterialTheme.colorScheme.onSurface,
+      )
+      Text(
+        text = price,
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.Bold,
+        color = MaterialTheme.colorScheme.primary,
+      )
+    }
+  }
+  val shape = RoundedCornerShape(16.dp)
+  val colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+  if (onClick != null) {
+    Card(onClick = onClick, modifier = Modifier.fillMaxWidth(), shape = shape, colors = colors) {
+      body()
+    }
+  } else {
+    Card(modifier = Modifier.fillMaxWidth(), shape = shape, colors = colors) { body() }
+  }
+}
+
+@NavPreview(route = Catalog::class, primary = true)
+@Preview(showBackground = true)
+@Composable
+internal fun CatalogScreenPreview() {
+  NavSampleTheme { CatalogScreen() }
+}
+
+@NavPreview(route = Product::class, primary = true)
+@Preview(showBackground = true)
+@Composable
+internal fun ProductScreenPreview() {
+  NavSampleTheme { ProductScreen() }
+}

--- a/samples/sample/src/main/kotlin/com/github/skydoves/navgraph/sample/orders/OrdersFeature.kt
+++ b/samples/sample/src/main/kotlin/com/github/skydoves/navgraph/sample/orders/OrdersFeature.kt
@@ -1,0 +1,200 @@
+/*
+ * Designed and developed by 2026 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.skydoves.navgraph.sample.orders
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation3.runtime.NavKey
+import com.github.skydoves.navgraph.annotations.NavDestination
+import com.github.skydoves.navgraph.annotations.NavEdge
+import com.github.skydoves.navgraph.annotations.NavPreview
+import com.github.skydoves.navgraph.sample.NavSampleTheme
+import kotlinx.serialization.Serializable
+
+/**
+ * The **orders** feature (package `...sample.orders`). `Orders -> OrderDetail` is an internal edge, so it
+ * survives the `orders` filter; `OrderDetail` is a leaf. The incoming `Checkout -> Orders` edge (declared over
+ * in the `cart` feature) is dropped when you scope to `orders`, since its source is outside this package (#19).
+ */
+@Serializable
+sealed interface OrdersKey : NavKey
+
+@Serializable
+data object Orders : OrdersKey
+
+@Serializable
+data class OrderDetail(val orderId: String) : OrdersKey
+
+@NavEdge(to = OrderDetail::class, label = "open")
+@NavDestination(route = Orders::class)
+@Composable
+fun OrdersScreen(onOpenOrder: (String) -> Unit = {}) {
+  val orders = listOf(
+    Triple("#1043", "Delivered", MaterialTheme.colorScheme.primary),
+    Triple("#1042", "Shipped", MaterialTheme.colorScheme.tertiary),
+    Triple("#1041", "Processing", MaterialTheme.colorScheme.secondary),
+  )
+  OrdersScaffold(title = "Orders") {
+    orders.forEachIndexed { index, (id, status, accent) ->
+      OrderRow(
+        id = id,
+        status = status,
+        accent = accent,
+        onClick = { onOpenOrder(id) }.takeIf { index == 0 },
+      )
+    }
+  }
+}
+
+@NavDestination(route = OrderDetail::class)
+@Composable
+fun OrderDetailScreen() {
+  OrdersScaffold(title = "Order #1043") {
+    Card(
+      modifier = Modifier.fillMaxWidth(),
+      shape = RoundedCornerShape(16.dp),
+      colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+    ) {
+      Column(
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+      ) {
+        Text(
+          text = "Delivered",
+          style = MaterialTheme.typography.titleMedium,
+          fontWeight = FontWeight.Bold,
+          color = MaterialTheme.colorScheme.primary,
+        )
+        Text(
+          text = "2 items · $218",
+          style = MaterialTheme.typography.bodyMedium,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+          text = "Arrived Jun 12, left at the front door.",
+          style = MaterialTheme.typography.bodyMedium,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+      }
+    }
+  }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun OrdersScaffold(title: String, content: @Composable () -> Unit) {
+  Scaffold(
+    topBar = {
+      TopAppBar(title = { Text(text = title, fontWeight = FontWeight.Bold) })
+    },
+    containerColor = MaterialTheme.colorScheme.surfaceVariant,
+  ) { innerPadding ->
+    Column(
+      modifier = Modifier
+        .fillMaxSize()
+        .padding(innerPadding)
+        .padding(16.dp),
+      verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+      content()
+    }
+  }
+}
+
+@Composable
+private fun OrderRow(
+  id: String,
+  status: String,
+  accent: androidx.compose.ui.graphics.Color,
+  onClick: (() -> Unit)?,
+) {
+  val body: @Composable () -> Unit = {
+    Row(
+      modifier = Modifier
+        .fillMaxWidth()
+        .padding(16.dp),
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+      Box(
+        modifier = Modifier
+          .size(10.dp)
+          .clip(CircleShape)
+          .background(accent),
+      )
+      Text(
+        text = id,
+        modifier = Modifier.weight(1f),
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.SemiBold,
+        color = MaterialTheme.colorScheme.onSurface,
+      )
+      Text(
+        text = status,
+        style = MaterialTheme.typography.labelLarge,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+    }
+  }
+  val shape = RoundedCornerShape(16.dp)
+  val colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+  if (onClick != null) {
+    Card(onClick = onClick, modifier = Modifier.fillMaxWidth(), shape = shape, colors = colors) {
+      body()
+    }
+  } else {
+    Card(modifier = Modifier.fillMaxWidth(), shape = shape, colors = colors) { body() }
+  }
+}
+
+@NavPreview(route = Orders::class, primary = true)
+@Preview(showBackground = true)
+@Composable
+internal fun OrdersScreenPreview() {
+  NavSampleTheme { OrdersScreen() }
+}
+
+@NavPreview(route = OrderDetail::class, primary = true)
+@Preview(showBackground = true)
+@Composable
+internal fun OrderDetailScreenPreview() {
+  NavSampleTheme { OrderDetailScreen() }
+}


### PR DESCRIPTION
This PR is for #19.

Lets a single-module app organized by feature packages view and export the navigation graph one feature at a time.

- Gradle: a new `-Pnavgraph.export.package=<prefix>` property on `exportNavGraphImage` / `exportNavGraphHtml` exports only the destinations under a package (matched by route or screen FQN), keeping internal edges and dropping cross-feature ones.
- IDE: a "Feature:" tool window selector, auto-discovered from the package layout, slices the graph by feature; the same selection scopes the export so the file matches the view. It stays hidden when the graph has nothing to split.
- Sample: feature-packaged screens (catalog, cart, orders) in `:sample` demonstrate the selector and the internal vs cross-feature edge behavior.
- Docs: the export and graph pages document the flag and the selector.

Verified end to end: IDE and Gradle unit tests green; on `:sample` the full graph is 14 nodes / 13 edges, and `-Pnavgraph.export.package=...sample.catalog` exports exactly the 2 catalog nodes plus their single internal edge (cross-feature edges dropped).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added feature/package-based filtering for navigation graph exports and the IDE graph view.
  * Exported diagrams can now be scoped to a single feature, and the selection is remembered in the IDE.
  * Added new sample screens for cart, catalog, and orders navigation flows.

* **Documentation**
  * Updated export and IDE docs with the new feature-scoping workflow and example usage.

* **Tests**
  * Added coverage for package filtering and feature grouping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->