### PR TITLE
Match the app's linked R.jar in the render classpath across AGP forms

### DIFF
--- a/compose-nav-graph-gradle/src/main/kotlin/com/github/skydoves/navgraph/gradle/NavGraphGradlePlugin.kt
+++ b/compose-nav-graph-gradle/src/main/kotlin/com/github/skydoves/navgraph/gradle/NavGraphGradlePlugin.kt
@@ -998,18 +998,22 @@ public class NavGraphGradlePlugin : Plugin<Project> {
           rClassPath.from(
             layout.buildDirectory.dir("intermediates").map { d ->
               // The FULL R closure — this module's R AND every dependency's R, incl. androidx (e.g.
-              // androidx.customview.poolingcontainer.R, which a ComposeView-backed preview loads at render). For an
-              // app the AAPT2-linked R is under compile_and_runtime_r_class_jar/<variant> (the app links
-              // everything); for a library the main R is module-only, so the closure lives under <variant>UnitTest.
-              // CRUCIAL: take ONLY the linked `process<…>Resources` R — whose IDs match the unit-test `.ap_` we
-              // feed — NOT the sibling `generate<…>StubRFile` R, a stub with PHANTOM ids. With non-transitive R a
-              // cross-module `R.string.x` is a non-final field resolved at render time; if the stub (listed first)
-              // wins the classloader, the id points at nothing in the `.ap_` → Resources$NotFoundException → a
-              // blank/failed render (this is why feature modules that reference another module's R went blank).
+              // androidx.customview.poolingcontainer.R$id, which EVERY ComposeView-backed preview loads at render
+              // via PoolingContainer.<clinit>; if it's absent the renderer aborts at ComposeViewAdapter and the
+              // preview silently falls back to the portrait Robolectric path). The app's AAPT2-linked R jar dir
+              // varies by AGP config/version — `compile_and_runtime_r_class_jar` OR
+              // `compile_and_runtime_not_namespaced_r_class_jar` — so match BOTH via `compile_and_runtime*r_class_jar`
+              // (the same wildcard wireKmpConsumerResources uses for the consuming app); a library's module-only R
+              // closure lives under <variant>UnitTest. CRUCIAL: take ONLY the linked `process<…>Resources` R — whose
+              // IDs match the unit-test `.ap_` we feed — NOT the sibling `generate<…>StubRFile` R, a stub with
+              // PHANTOM ids. With non-transitive R a cross-module `R.string.x` is a non-final field resolved at
+              // render time; if the stub (listed first) wins the classloader, the id points at nothing in the `.ap_`
+              // → Resources$NotFoundException → a blank/failed render (why feature modules referencing another
+              // module's R went blank).
               fileTree(d.asFile).matching {
                 include(
-                  "**/compile_and_runtime_r_class_jar/$v/process*Resources/R.jar",
-                  "**/compile_and_runtime_r_class_jar/${v}UnitTest/process*Resources/R.jar",
+                  "**/compile_and_runtime*r_class_jar/$v/process*Resources/R.jar",
+                  "**/compile_and_runtime*r_class_jar/${v}UnitTest/process*Resources/R.jar",
                 )
               }
             },


### PR DESCRIPTION
Addresses the rendering problem reported in #13 (the `@Preview` size fix shipped in 0.1.2 never runs while the Layoutlib pass fails).

Every ComposeView-backed preview loads `androidx.customview.poolingcontainer.R$id` at `PoolingContainer.<clinit>`. That class ships only in the app's AAPT2-linked R.jar (the runtime jar strips it). The non-KMP render path matched that jar at `compile_and_runtime_r_class_jar` only, but an app's linked R can live under `compile_and_runtime_not_namespaced_r_class_jar` depending on the AGP config or version. When it does, the R.jar is dropped from the render classpath, so every preview crashes at `ComposeViewAdapter` and falls back to the portrait Robolectric path with the `@Preview` size ignored.

Fix: match both forms with the `compile_and_runtime*r_class_jar` wildcard, the same pattern `wireKmpConsumerResources` already uses for KMP consuming apps.

Verified on `:sample`: simulating the unmatched form reproduces the failure (Layoutlib 0/15, every preview reports a `poolingcontainer.R$id` broken class and falls back to portrait); with the wildcard the Layoutlib pass renders all previews (0 fallback, no broken classes, real pixels). `compose-nav-graph-gradle` tests and spotless are green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thumbnail rendering for Kotlin Multiplatform projects by more reliably finding the app’s resource files.
  * Better support for different Android build output layouts, reducing cases where preview assets failed to load or showed the wrong resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->